### PR TITLE
fix: use 'object' as default classification

### DIFF
--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -82,6 +82,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// Classification of the object
         /// </summary>
         public string Classification { get; set; }
+        private const string DefaultClassification = "object";
 
         internal MetasysObject(JToken token, ApiVersion version, IEnumerable<MetasysObject> children = null, MetasysObjectTypeEnum? type =null)
         {
@@ -187,11 +188,19 @@ namespace JohnsonControls.Metasys.BasicServices
             }
             try
             {
-                Classification = jobj.ContainsKey("classification") ? token["classification"].Value<string>() : null;
+                if (jobj.ContainsKey("classification")) 
+                {
+                    var tokenValue = token["classification"].Value<string>().Trim();
+                    Classification = tokenValue == string.Empty ? DefaultClassification : tokenValue;
+                }
+                else
+                {
+                    Classification = DefaultClassification;
+                }
             }
             catch
             {
-                Classification = null;
+                Classification = DefaultClassification;
             }
         }
 


### PR DESCRIPTION
The REST API operations that return collections of objects include a `classification` property. Many nodes in the tree come back with a value of `""` for this property. However those nodes should be classified with `"object"` instead. This is being resolved in the REST API; however this commit addresses the issue when this client is used with older unpatched Metasys devices.