### PR TITLE
remove unchanged heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [6.0.4] - 2024-07-25
 ### Changed
 - Fixed issue related to the method 'GetObjects()' (specifically related to the attribute 'Classification')


### PR DESCRIPTION
It's always been confusing as it makes it look like everything below is "unreleased". This is because we never update this section and so it looks like a header over the rest of the doc.

I think it looks cleaner now:

<img width="910" alt="image" src="https://github.com/user-attachments/assets/333554c2-ae55-4677-80a3-4a351689c83f">
