### PR TITLE
feat: use ObjectId for object ids in MetasysClient

### DIFF
--- a/MetasysServices.Tests/ObjectIdTests.cs
+++ b/MetasysServices.Tests/ObjectIdTests.cs
@@ -1,0 +1,58 @@
+using System;
+using NUnit.Framework;
+
+namespace JohnsonControls.Metasys.BasicServices;
+
+[TestFixture]
+public class ObjectIdTests
+{
+    // Mainly just making sure we never get a Null exception due to the default constructor
+    // This was really addressed by the fact that I switched ObjectId to be a record,
+    // changed the language in csproj to 12 and provided a default constructor that ensures
+    // we default to empty string
+    [Test]
+    public void DefaultInstanceNeverThrows()
+    {
+        // Arrange
+        var id = new ObjectId();
+
+        // Assertions
+        Assert.That(id.ToString(), Is.EqualTo(""));
+        Assert.That((string)id, Is.EqualTo(""));
+        Assert.That(id == "", Is.True);
+        Assert.That(id.GetHashCode(), Is.EqualTo(id.ToString().GetHashCode()));
+    }
+
+
+    // Basically make sure conversions to/from string are correct
+    [TestCase("")]
+    [TestCase("54efad4c-0fb7-59b4-9b6f-e385fd7e5b9e")]
+    [TestCase("Happy Data 😃")]
+    public void StringConversions(string inputString)
+    {
+        // Act
+        ObjectId objectId = inputString;
+
+        // Assert
+        Assert.That(objectId, Is.EqualTo(inputString));
+        Assert.That(objectId, Is.EqualTo(new ObjectId(inputString)));
+        Assert.That(inputString, Is.EqualTo(objectId));
+        Assert.That(inputString, Is.EqualTo(objectId.ToString()));
+        Assert.That(objectId == inputString, Is.True);
+        Assert.That(objectId != inputString, Is.False);
+        Assert.That(objectId != "78f5c3ca-46e1-5f93-b06e-5711677bf933", Is.True);
+    }
+
+    [TestCase("54efad4c-0fb7-59b4-9b6f-e385fd7e5b9e")]
+    public void GuidConversions(string inputString)
+    {
+        // Act
+        var guid = new Guid(inputString);
+        ObjectId objectId = guid;
+
+        // Assert
+        Assert.That(objectId, Is.EqualTo(guid));
+        Assert.That(objectId, Is.EqualTo(new ObjectId(inputString)));
+        Assert.That(guid, Is.EqualTo(objectId));
+    }
+}

--- a/MetasysServices/Alarms/AlarmServiceProvider.cs
+++ b/MetasysServices/Alarms/AlarmServiceProvider.cs
@@ -127,12 +127,12 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public PagedResult<Alarm> GetForObject(Guid objectId, AlarmFilter alarmFilter)
+        public PagedResult<Alarm> GetForObject(ObjectId objectId, AlarmFilter alarmFilter)
         {
             return GetForObjectAsync(objectId, alarmFilter).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Alarm>> GetForObjectAsync(Guid objectId, AlarmFilter alarmFilter)
+        public async Task<PagedResult<Alarm>> GetForObjectAsync(ObjectId objectId, AlarmFilter alarmFilter)
         {
             CheckVersion(Version);
 
@@ -157,12 +157,12 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public PagedResult<Alarm> GetForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter)
+        public PagedResult<Alarm> GetForNetworkDevice(ObjectId networkDeviceId, AlarmFilter alarmFilter)
         {
             return GetForNetworkDeviceAsync(networkDeviceId, alarmFilter).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Alarm>> GetForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter alarmFilter)
+        public async Task<PagedResult<Alarm>> GetForNetworkDeviceAsync(ObjectId networkDeviceId, AlarmFilter alarmFilter)
         {
             CheckVersion(Version);
 

--- a/MetasysServices/Alarms/IAlarmService.cs
+++ b/MetasysServices/Alarms/IAlarmService.cs
@@ -89,10 +89,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="networkDeviceId">The identifier of the network device.</param>
         /// <param name="alarmFilter">The filter to be applied to alarms list.</param>
         /// <returns>The list of alarms with details.</returns>
-        PagedResult<Alarm> GetForNetworkDevice(Guid networkDeviceId, AlarmFilter alarmFilter);
+        PagedResult<Alarm> GetForNetworkDevice(ObjectId networkDeviceId, AlarmFilter alarmFilter);
 
-        /// <inheritdoc cref="IAlarmsService.GetForNetworkDevice(Guid, AlarmFilter)"/>
-        Task<PagedResult<Alarm>> GetForNetworkDeviceAsync(Guid networkDeviceId, AlarmFilter alarmFilter);
+        /// <inheritdoc cref="IAlarmsService.GetForNetworkDevice(ObjectId, AlarmFilter)"/>
+        Task<PagedResult<Alarm>> GetForNetworkDeviceAsync(ObjectId networkDeviceId, AlarmFilter alarmFilter);
 
         // --------------------------------------------------------------------------------------------------
         /// <summary>
@@ -101,10 +101,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="objectId">The identifier of the object.</param>
         /// <param name="alarmFilter">The filter to be applied to alarms list.</param>
         /// <returns>The list of alarms with details.</returns>
-        PagedResult<Alarm> GetForObject(Guid objectId, AlarmFilter alarmFilter);
+        PagedResult<Alarm> GetForObject(ObjectId objectId, AlarmFilter alarmFilter);
 
-        /// <inheritdoc cref="AlarmServiceProvider.GetForObject(Guid, AlarmFilter)"/> 
-        Task<PagedResult<Alarm>> GetForObjectAsync(Guid objectId, AlarmFilter alarmFilter);
+        /// <inheritdoc cref="AlarmServiceProvider.GetForObject(ObjectId, AlarmFilter)"/>
+        Task<PagedResult<Alarm>> GetForObjectAsync(ObjectId objectId, AlarmFilter alarmFilter);
 
     }
 }

--- a/MetasysServices/Audits/AuditServiceProvider.cs
+++ b/MetasysServices/Audits/AuditServiceProvider.cs
@@ -81,7 +81,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public async Task<PagedResult<Audit>> GetForObjectAsync(Guid objectId, AuditFilter auditFilter)
+        public async Task<PagedResult<Audit>> GetForObjectAsync(ObjectId objectId, AuditFilter auditFilter)
         {
             CheckVersion(Version);
 
@@ -150,7 +150,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public PagedResult<Audit> GetForObject(Guid objectId, AuditFilter auditFilter)
+        public PagedResult<Audit> GetForObject(ObjectId objectId, AuditFilter auditFilter)
         {
             return GetForObjectAsync(objectId, auditFilter).GetAwaiter().GetResult();
         }

--- a/MetasysServices/Audits/IAuditService.cs
+++ b/MetasysServices/Audits/IAuditService.cs
@@ -47,10 +47,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="objectId">The identifier of the object.</param>
         /// <param name="auditFilter">The filter to be applied to audit list.</param>
         /// <returns>The list of audit with details.</returns>
-        PagedResult<Audit> GetForObject(Guid objectId, AuditFilter auditFilter);
+        PagedResult<Audit> GetForObject(ObjectId objectId, AuditFilter auditFilter);
 
-        /// <inheritdoc cref="IAuditService.GetForObject(Guid, AuditFilter)"/>
-        Task<PagedResult<Audit>> GetForObjectAsync(Guid objectId, AuditFilter auditFilter);
+        /// <inheritdoc cref="IAuditService.GetForObject(ObjectId, AuditFilter)"/>
+        Task<PagedResult<Audit>> GetForObjectAsync(ObjectId objectId, AuditFilter auditFilter);
 
         /// <summary>
         /// Discard an Audit.

--- a/MetasysServices/BasicServiceProvider.cs
+++ b/MetasysServices/BasicServiceProvider.cs
@@ -163,7 +163,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <summary>
-        /// Gets all child objects given a parent Guid asynchronously by requesting each available page.
+        /// Gets all child objects given a parent id asynchronously by requesting each available page.
         /// Level indicates how deep to retrieve objects.
         /// </summary>
         /// <remarks>
@@ -174,7 +174,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="levels">The number of levels to retrieve children.</param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <exception cref="MetasysHttpParsingException"></exception>
-        protected async Task<List<TreeObject>> GetObjectChildrenAsync(Guid id, Dictionary<string, string> parameters = null, int levels = 1)
+        protected async Task<List<TreeObject>> GetObjectChildrenAsync(Object id, Dictionary<string, string> parameters = null, int levels = 1)
         {
             if (levels < 1)
             {
@@ -293,7 +293,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <summary>
-        /// Gets the type from a token retrieved from a typeUrl 
+        /// Gets the type from a token retrieved from a typeUrl
         /// </summary>
         /// <param name="typeToken"></param>
         /// <exception cref="MetasysHttpException"></exception>
@@ -463,25 +463,32 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <summary>
-        /// Parses a JToken and creates a Guid.
+        /// Parses a JToken containing a string and returns the value as an <see cref="ObjectId"/>.
         /// </summary>
         /// <param name="token"></param>
         /// <exception cref="MetasysGuidException"></exception>
-        /// <returns>A Guid representation of the JToken.</returns>
-        protected Guid ParseObjectIdentifier(JToken token)
+        /// <returns>The <see cref="ObjectId"/> contained in the token.</returns>
+        protected ObjectId ParseObjectIdentifier(JToken token)
         {
             string str = null;
             try
             {
-                str = token.Value<string>();
-                var id = new Guid(str);
-                return id;
+                if (token.Type == JTokenType.String)
+                {
+                    str = token.Value<string>();
+                    return str;
+                }
             }
             catch (Exception e) when (e is System.ArgumentNullException ||
                 e is System.ArgumentException || e is System.FormatException)
             {
+                // This still throws a MetasysGuidException rather than a new type of
+                // exception to support backward compatibility even though we don't
+                // use Guids any more.
                 throw new MetasysGuidException(str, e);
             }
+
+            throw new MetasysGuidException(token.ToString(), null);
         }
 
         /// <summary>
@@ -501,7 +508,7 @@ namespace JohnsonControls.Metasys.BasicServices
             JToken response = null;
             // Create URL with base resource
             Url url = new Url(resource);
-            // Concatenate segments with base resource url 
+            // Concatenate segments with base resource url
             url.AppendPathSegments(pathSegments);
             // Set query parameters according to the input dictionary
             if (parameters != null)
@@ -527,7 +534,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <summary>
-        /// Get typed items for the given resource asynchronously. 
+        /// Get typed items for the given resource asynchronously.
         /// </summary>
         /// <remarks>Optionally accepts query string parameters and additional path segments.</remarks>
         /// <typeparam name="T"></typeparam>
@@ -543,7 +550,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
 
         /// <summary>
-        /// Gets all items for the given resource asynchronously by requesting each available page.      
+        /// Gets all items for the given resource asynchronously by requesting each available page.
         /// </summary>
         /// <param name="resource">The main resource to read.</param>
         /// <param name="parameters">Query string parameters in Key Value format.</param>
@@ -667,14 +674,14 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="resources"></param>
         /// <param name="paths"></param>
         /// <returns></returns>
-        protected async Task<JToken> GetBatchRequestAsync(string endpoint, IEnumerable<Guid> ids, IEnumerable<string> resources, params string[] paths)
+        protected async Task<JToken> GetBatchRequestAsync(string endpoint, IEnumerable<ObjectId> ids, IEnumerable<string> resources, params string[] paths)
         {
             // Create URL with base resource
             Url url = new Url(endpoint);
             // Concatenate batch segment to use batch request and prepare the list of requests
             url.AppendPathSegments("batch");
             var objectsRequests = new List<ObjectRequest>();
-            // Concatenate batch segment to use batch request and prepare the list of requests  
+            // Concatenate batch segment to use batch request and prepare the list of requests
             foreach (var id in ids)
             {
                 foreach (var r in resources)
@@ -716,7 +723,7 @@ namespace JohnsonControls.Metasys.BasicServices
             // Concatenate batch segment to use batch request and prepare the list of requests
             url.AppendPathSegments("batch");
             var objectsRequests = new List<ObjectRequest>();
-            // Concatenate batch segment to use batch request and prepare the list of requests  
+            // Concatenate batch segment to use batch request and prepare the list of requests
             foreach (var r in requests)
             {
                 Url relativeUrl = new Url(r.ObjectId.ToString());
@@ -778,7 +785,7 @@ namespace JohnsonControls.Metasys.BasicServices
             // Concatenate batch segment to use batch request and prepare the list of requests
             url.AppendPathSegments("batch");
             var objectsRequests = new List<ObjectRequest>();
-            // Concatenate batch segment to use batch request and prepare the list of requests  
+            // Concatenate batch segment to use batch request and prepare the list of requests
             foreach (var r in requests)
             {
                 Url relativeUrl = new Url(r.ObjectId.ToString());
@@ -851,7 +858,7 @@ namespace JohnsonControls.Metasys.BasicServices
             // Concatenate batch segment to use batch request and prepare the list of requests
             url.AppendPathSegments("batch");
             var objectsRequests = new List<ObjectRequest>();
-            // Concatenate batch segment to use batch request and prepare the list of requests  
+            // Concatenate batch segment to use batch request and prepare the list of requests
             foreach (var r in requests)
             {
                 string activityManagementStatus = "";

--- a/MetasysServices/Equipments/EquipmentServiceProvider.cs
+++ b/MetasysServices/Equipments/EquipmentServiceProvider.cs
@@ -34,12 +34,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // FindById -----------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public MetasysObject FindById(Guid equipmentId)
+        public MetasysObject FindById(ObjectId equipmentId)
         {
             return FindByIdAsync(equipmentId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<MetasysObject> FindByIdAsync(Guid equipmentId)
+        public async Task<MetasysObject> FindByIdAsync(ObjectId equipmentId)
         {
             CheckVersion(Version);
 
@@ -70,12 +70,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetPoints -------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysPoint> GetPoints(Guid equipmentId, bool readAttributeValue = true)
+        public IEnumerable<MetasysPoint> GetPoints(ObjectId equipmentId, bool readAttributeValue = true)
         {
             return GetPointsAsync(equipmentId, readAttributeValue).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysPoint>> GetPointsAsync(Guid equipmentId, bool readAttributeValue = true)
+        public async Task<IEnumerable<MetasysPoint>> GetPointsAsync(ObjectId equipmentId, bool readAttributeValue = true)
         {
             CheckVersion(Version);
 
@@ -87,10 +87,10 @@ namespace JohnsonControls.Metasys.BasicServices
                 foreach (var item in response)
                 {
                     MetasysPoint point = new MetasysPoint(item);
-                    // Retrieve object Id from full URL 
+                    // Retrieve object Id from full URL
                     string objectId = point.ObjectUrl.Split('/').Last();
                     point.ObjectId = ParseObjectIdentifier(objectId);
-                    // Retrieve attribute Id from full URL 
+                    // Retrieve attribute Id from full URL
                     string attributeId = (point.Attribute != null) ? point.Attribute.Split('.').Last() : String.Empty;
                     if (attributeId == String.Empty)
                     {
@@ -122,15 +122,14 @@ namespace JohnsonControls.Metasys.BasicServices
             }
             return points;
         }
-
         // GetServingASpace --------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetServingASpace(Guid spaceId)
+        public IEnumerable<MetasysObject> GetServingASpace(ObjectId spaceId)
         {
             return GetServingASpaceAsync(spaceId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetServingASpaceAsync(Guid spaceId)
+        public async Task<IEnumerable<MetasysObject>> GetServingASpaceAsync(ObjectId spaceId)
         {
             CheckVersion(Version);
 
@@ -140,12 +139,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetHostedByNetworkDevice --------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetHostedByNetworkDevice(Guid networkDeviceId)
+        public IEnumerable<MetasysObject> GetHostedByNetworkDevice(ObjectId networkDeviceId)
         {
             return GetHostedByNetworkDeviceAsync(networkDeviceId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetHostedByNetworkDeviceAsync(Guid networkDeviceId)
+        public async Task<IEnumerable<MetasysObject>> GetHostedByNetworkDeviceAsync(ObjectId networkDeviceId)
         {
             CheckVersion(Version);
 
@@ -155,12 +154,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetServedByEquipment -----------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetServedByEquipment(Guid equipmentId)
+        public IEnumerable<MetasysObject> GetServedByEquipment(ObjectId equipmentId)
         {
             return GetServedByEquipmentAsync(equipmentId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(Guid equipmentId)
+        public async Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(ObjectId equipmentId)
         {
             CheckVersion(Version);
 
@@ -170,17 +169,18 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetServingAnEquipment --------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetServingAnEquipment(Guid equipmentId)
+        public IEnumerable<MetasysObject> GetServingAnEquipment(ObjectId equipmentId)
         {
             return GetServingAnEquipmentAsync(equipmentId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetServingAnEquipmentAsync(Guid equipmentId)
+        public async Task<IEnumerable<MetasysObject>> GetServingAnEquipmentAsync(ObjectId equipmentId)
         {
             CheckVersion(Version);
 
             var spaceEquipment = await GetAllAvailablePagesAsync("equipment", null, equipmentId.ToString(), "upstreamEquipment").ConfigureAwait(false);
             return ToMetasysObject(spaceEquipment, Version, MetasysObjectTypeEnum.Equipment);
         }
+
     }
 }

--- a/MetasysServices/Equipments/IEquipmentService.cs
+++ b/MetasysServices/Equipments/IEquipmentService.cs
@@ -16,9 +16,9 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Retrieves the specified equipment instance.
         /// </summary>
-        MetasysObject FindById(Guid equipmentId);
-        /// <inheritdoc cref="IEquipmentService.FindById(Guid)"/>
-        Task<MetasysObject> FindByIdAsync(Guid equipmentId);
+        MetasysObject FindById(ObjectId equipmentId);
+        /// <inheritdoc cref="IEquipmentService.FindById(ObjectId)"/>
+        Task<MetasysObject> FindByIdAsync(ObjectId equipmentId);
 
         // Get ---------------------------------------------------------------------------------------------------------------------
         /// <summary>
@@ -35,48 +35,51 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Retrieves the collection of points that are defined by the specified equipment instance.
         /// </summary>
-        /// <param name="equipmentId">The Guid of the equipment.</param>
+        /// <param name="equipmentId">The id of the equipment.</param>
         /// <param name="readAttributeValue">Set to false if you would not read Points Attribute Value.</param>
         /// <remarks> Reading the Attribute Value attribute could take time depending on the number of points. </remarks>
         /// <returns></returns>
-        IEnumerable<MetasysPoint> GetPoints(Guid equipmentId, bool readAttributeValue = true);
-        /// <inheritdoc cref="IEquipmentService.GetPoints(Guid, bool)"/>
-        Task<IEnumerable<MetasysPoint>> GetPointsAsync(Guid equipmentId, bool readAttributeValue = true);
+        IEnumerable<MetasysPoint> GetPoints(ObjectId equipmentId, bool readAttributeValue = true);
+        /// <inheritdoc cref="IEquipmentService.GetPoints(ObjectId, bool)"/>
+        Task<IEnumerable<MetasysPoint>> GetPointsAsync(ObjectId equipmentId, bool readAttributeValue = true);
+
+
 
         // GetServingASpace ------------------------------------------------------------------------------------------------------------
         /// <summary>
         /// Retrieves the collection of equipment that serve the specified space.
         /// </summary>
         /// <param name="spaceId"></param>
-        IEnumerable<MetasysObject> GetServingASpace(Guid spaceId);
-        /// <inheritdoc cref="IEquipmentService.GetServingASpace(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetServingASpaceAsync(Guid spaceId);
+        IEnumerable<MetasysObject> GetServingASpace(ObjectId spaceId);
+        /// <inheritdoc cref="IEquipmentService.GetServingASpace(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetServingASpaceAsync(ObjectId spaceId);
 
         // GetHostedByNetworkDevice ------------------------------------------------------------------------------------------------------------
         /// <summary>
         /// Retrieves the collection of equipment instances that are hosted by the specified network device or its children.
         /// </summary>
         /// <param name="networkDeviceId"></param>
-        IEnumerable<MetasysObject> GetHostedByNetworkDevice(Guid networkDeviceId);
-        /// <inheritdoc cref="IEquipmentService.GetServingASpace(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetHostedByNetworkDeviceAsync(Guid networkDeviceId);
+        IEnumerable<MetasysObject> GetHostedByNetworkDevice(ObjectId networkDeviceId);
+        /// <inheritdoc cref="IEquipmentService.GetServingASpace(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetHostedByNetworkDeviceAsync(ObjectId networkDeviceId);
+
 
         // GetServedByEquipment ----------------------------------------------------------------------------------------------------------------
         /// <summary>
         /// Retrieves the equipment served by the specified equipment instance.
         /// </summary>
-        IEnumerable<MetasysObject> GetServedByEquipment(Guid equipmentId);
-        /// <inheritdoc cref="IEquipmentService.GetServedByEquipment(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(Guid equipmentId);
+        IEnumerable<MetasysObject> GetServedByEquipment(ObjectId equipmentId);
+        /// <inheritdoc cref="IEquipmentService.GetServedByEquipment(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(ObjectId equipmentId);
 
         // GetServingAnEquipment ------------------------------------------------------------------------------------------------------------
         /// <summary>
         /// Retrieves the collection of equipment that serve the specified equipment instance.
         /// </summary>
         /// <param name="equipmentId"></param>
-        IEnumerable<MetasysObject> GetServingAnEquipment(Guid equipmentId);
-        /// <inheritdoc cref="IEquipmentService.GetServingAnEquipment(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetServingAnEquipmentAsync(Guid equipmentId);
+        IEnumerable<MetasysObject> GetServingAnEquipment(ObjectId equipmentId);
+        /// <inheritdoc cref="IEquipmentService.GetServingAnEquipment(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetServingAnEquipmentAsync(ObjectId equipmentId);
 
     }
 }

--- a/MetasysServices/Extensions/MetasysObjectCollectionExtension.cs
+++ b/MetasysServices/Extensions/MetasysObjectCollectionExtension.cs
@@ -32,7 +32,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="source"></param>
         /// <param name="id">The Id of the Metasys Object.</param>
         /// <returns></returns>
-        public static MetasysObject FindById(this IEnumerable<MetasysObject> source, Guid id)
+        public static MetasysObject FindById(this IEnumerable<MetasysObject> source, ObjectId id)
         {
             var metasysObject = source.FirstOrDefault(f => f.Id == id);
             if (metasysObject == null)

--- a/MetasysServices/Extensions/VariantMultipleCollectionExtension.cs
+++ b/MetasysServices/Extensions/VariantMultipleCollectionExtension.cs
@@ -29,7 +29,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="source"></param>
         /// <param name="id">The Id of the Metasys Object.</param>
         /// <returns></returns>
-        public static VariantMultiple FindById(this IEnumerable<VariantMultiple> source, Guid id)
+        public static VariantMultiple FindById(this IEnumerable<VariantMultiple> source, ObjectId id)
         {
             var multiples = source.FirstOrDefault(f => f.Id == id);
             return multiples ?? throw new Exception($"VariantMultiple not found in the collection ({id}).");

--- a/MetasysServices/Interfaces/IMetasysClient.cs
+++ b/MetasysServices/Interfaces/IMetasysClient.cs
@@ -162,17 +162,15 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <remarks>
         /// The itemReference will be automatically URL encoded.
         /// </remarks>
-        /// <returns>A Guid representing the id, or an empty Guid if errors occurred.</returns>
+        /// <returns>An <see cref="ObjectId"/> for the specified object.</returns>
         /// <param name="itemReference"></param>
         /// <exception cref="MetasysHttpException"></exception>
-        /// <exception cref="MetasysGuidException"></exception>
-        Guid GetObjectIdentifier(string itemReference);
+        ObjectId GetObjectIdentifier(string itemReference);
         /// <inheritdoc cref="IMetasysClient.GetObjectIdentifier(string)"/>
-        Task<Guid> GetObjectIdentifierAsync(string itemReference);
-
+        Task<ObjectId> GetObjectIdentifierAsync(string itemReference);
 
         /// <summary>
-        /// Read one attribute value given the Guid of the object.
+        /// Read one attribute value given the id of the object.
         /// </summary>
         /// <returns>
         /// Variant if the attribute exists, null if does not exist.
@@ -184,70 +182,70 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysPropertyException"></exception>
-        Variant ReadProperty(Guid id, string attributeName);
-        /// <inheritdoc cref="IMetasysClient.ReadProperty(Guid, string)"/>
-        Task<Variant> ReadPropertyAsync(Guid id, string attributeName);
+        Variant ReadProperty(ObjectId id, string attributeName);
+        /// <inheritdoc cref="IMetasysClient.ReadProperty(ObjectId, string)"/>
+        Task<Variant> ReadPropertyAsync(ObjectId id, string attributeName);
 
 
         /// <summary>
-        /// Read many attribute values given the Guids of the objects.
+        /// Read many attribute values given the ids of the objects.
         /// </summary>
         /// <returns>
-        /// A list of VariantMultiple with all the specified attributes (if existing).        
+        /// A list of VariantMultiple with all the specified attributes (if existing).
         /// </returns>
         /// <param name="ids"></param>
-        /// <param name="attributeNames"></param>        
+        /// <param name="attributeNames"></param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <exception cref="MetasysPropertyException"></exception>
-        IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<Guid> ids, IEnumerable<string> attributeNames);
-        /// <inheritdoc cref="IMetasysClient.ReadPropertyMultiple(IEnumerable{Guid}, IEnumerable{string})"/>
-        Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<string> attributeNames);
-
+        IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<ObjectId> ids, IEnumerable<string> attributeNames);
+        /// <inheritdoc cref="IMetasysClient.ReadPropertyMultiple(IEnumerable{ObjectId}, IEnumerable{string})"/>
+        Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<ObjectId> ids, IEnumerable<string> attributeNames);
 
         /// <summary>
-        /// Write a single attribute given the Guid of the object.
+        /// Write a single attribute given the id of the object.
         /// </summary>
         /// <param name="id">The id of the attribute</param>
         /// <param name="attributeName">The name of the attribute</param>
         /// <param name="newValue">The new value of the attribute</param>
         /// <exception cref="MetasysHttpException"></exception>
-        void WriteProperty(Guid id, string attributeName, object newValue);
-        /// <inheritdoc cref="IMetasysClient.WriteProperty(Guid, string, object)"/>
-        Task WritePropertyAsync(Guid id, string attributeName, object newValue);
+        void WriteProperty(ObjectId id, string attributeName, object newValue);
+        /// <inheritdoc cref="IMetasysClient.WriteProperty(ObjectId, string, object)"/>
+        Task WritePropertyAsync(ObjectId id, string attributeName, object newValue);
 
 
         /// <summary>
-        /// Write to many attribute values given the Guids of the objects.
+        /// Write to many attribute values given the ids of the objects.
         /// </summary>
         /// <param name="ids"></param>
         /// <param name="attributeValues">The (attribute, value) pairs.</param>
         /// <exception cref="MetasysHttpException"></exception>
-        void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
+        void WritePropertyMultiple(IEnumerable<ObjectId> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
         /// <summary>
-        /// Write to many attribute values given the Guids of the objects.
+        /// Write to many attribute values given the ids of the objects.
         /// </summary>
         /// <param name="ids"></param>
         /// <param name="attributeValues">The (attribute, value) pairs.</param>
         /// <exception cref="MetasysHttpException"></exception>
-        void WritePropertyMultiple(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues);
+        void WritePropertyMultiple(IEnumerable<ObjectId> ids, Dictionary<string, object> attributeValues);
 
 
         /// <summary>
-        /// Write asyncronously to many attribute values given the Guids of the objects.
+        /// Write asynchronously to many attribute values given the ids of the objects.
         /// </summary>
-        Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
-        /// <inheritdoc cref="IMetasysClient.WritePropertyMultiple(IEnumerable{Guid}, Dictionary{string, object})"/>
-        Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues);
+        Task WritePropertyMultipleAsync(IEnumerable<ObjectId> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
+        /// <inheritdoc cref="IMetasysClient.WritePropertyMultiple(IEnumerable{ObjectId}, Dictionary{string, object})"/>
+        Task WritePropertyMultipleAsync(IEnumerable<ObjectId> ids, Dictionary<string, object> attributeValues);
+
 
 
         /// <summary>
-        /// Get all available commands given the Guid of the object.
+        /// Get all available commands given the id of the object.
         /// </summary>
         /// <param name="id"></param>
         /// <returns>List of Commands.</returns>
-        IEnumerable<Command> GetCommands(Guid id);
-        /// <inheritdoc cref="IMetasysClient.GetCommands(Guid)"/>
-        Task<IEnumerable<Command>> GetCommandsAsync(Guid id);
+        IEnumerable<Command> GetCommands(ObjectId id);
+        /// <inheritdoc cref="IMetasysClient.GetCommands(ObjectId)"/>
+        Task<IEnumerable<Command>> GetCommandsAsync(ObjectId id);
 
 
         /// <summary>
@@ -257,22 +255,25 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="command"></param>
         /// <param name="values"></param>
         /// <exception cref="MetasysHttpException"></exception>
-        void SendCommand(Guid id, string command, IEnumerable<object> values = null);
-        /// <inheritdoc cref="IMetasysClient.SendCommand(Guid, string, IEnumerable{object})"/>
-        Task SendCommandAsync(Guid id, string command, IEnumerable<object> values = null);
-
+        void SendCommand(ObjectId id, string command, IEnumerable<object> values = null);
+        /// <inheritdoc cref="IMetasysClient.SendCommand(ObjectId, string, IEnumerable{object})"/>
+        Task SendCommandAsync(ObjectId id, string command, IEnumerable<object> values = null);
 
         /// <summary>
-        /// Gets all network devices.
+        /// <s>Gets all network devices.</s>
         /// </summary>
         /// <remarks>
-        /// Note this method has been deprecated.
+        /// <b>Note this method has been deprecated.</b> Please use
+        /// <see cref="GetNetworkDevices(NetworkDeviceTypeEnum)"/>
+        /// or <see cref="GetNetworkDevicesAsync(NetworkDeviceTypeEnum)"/> instead.
         /// </remarks>
         /// <param name="type">Optional type number as a string</param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <exception cref="MetasysHttpParsingException"></exception>
+        [Obsolete("Use GetNetworkDevices(NetworkDeviceTypeEnum) instead.")]
         IEnumerable<MetasysObject> GetNetworkDevices(string type = null);
         /// <inheritdoc cref="IMetasysClient.GetNetworkDevices(string)"/>
+        [Obsolete("Use GetNetworkDevicesAsync(NetworkDeviceTypeEnum) instead.")]
         Task<IEnumerable<MetasysObject>> GetNetworkDevicesAsync(string type = null);
 
 
@@ -298,7 +299,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
 
         /// <summary>
-        /// Gets all child objects given a parent Guid.
+        /// Gets all child objects given a parent id.
         /// Level indicates how deep to retrieve objects.
         /// </summary>
         /// <remarks>
@@ -306,59 +307,70 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </remarks>
         /// <param name="id">The ID of the parent object.</param>
         /// <param name="levels">The depth of the children to retrieve.</param>
-        /// <param name="includeInternalObjects">Set it to true to see also internal objects that are not displayed in the Metasys tree. </param>      
-        /// <param name="includeExtensions">Set it to true to get also the extensions of the object.</param>      
+        /// <param name="includeInternalObjects">Set it to true to see also internal objects that are not displayed in the Metasys tree. </param>
+        /// <param name="includeExtensions">Set it to true to get also the extensions of the object.</param>
         /// <remarks> The flag includeInternalObjects applies since Metasys API v3. </remarks>
         /// <exception cref="MetasysHttpException"></exception>
         /// <exception cref="MetasysHttpParsingException"></exception>
-        IEnumerable<MetasysObject> GetObjects(Guid id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false);
-        /// <inheritdoc cref="IMetasysClient.GetObjects(Guid, int, bool, bool)"/>
-        Task<IEnumerable<MetasysObject>> GetObjectsAsync(Guid id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false);
+        IEnumerable<MetasysObject> GetObjects(ObjectId id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false);
+        /// <inheritdoc cref="IMetasysClient.GetObjects(ObjectId, int, bool, bool)"/>
+        Task<IEnumerable<MetasysObject>> GetObjectsAsync(ObjectId id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false);
 
         /// <summary>
-        /// Gets all child objects given a parent Guid and object type.
+        /// Gets all child objects given a parent id and object type.
         /// </summary>
         /// <param name="objectId"></param>
         /// <param name="objectType">The object type enum set.</param>
         /// <exception cref="MetasysHttpException"></exception>
-        /// <exception cref="MetasysHttpParsingException"></exception>        
-        IEnumerable<MetasysObject> GetObjects(Guid objectId, string objectType);
+        /// <exception cref="MetasysHttpParsingException"></exception>
+        IEnumerable<MetasysObject> GetObjects(ObjectId objectId, string objectType);
 
-        /// <inheritdoc cref="IMetasysClient.GetObjects(Guid, string)"/>
-        Task<IEnumerable<MetasysObject>> GetObjectsAsync(Guid objectId, string objectType);
+        /// <inheritdoc cref="IMetasysClient.GetObjects(ObjectId, string)"/>
+        Task<IEnumerable<MetasysObject>> GetObjectsAsync(ObjectId objectId, string objectType);
 
         #region "SPACES" //==============================================================================================================
         // GetSpaces ---------------------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves a collection of spaces.
+        /// <s>Retrieves a collection of spaces.</s>
         /// </summary>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Spaces service).
+        /// <b>This method is deprecated</b> Please use
+        /// <see cref="SpaceServiceProvider.Get(SpaceTypeEnum?, int?, int?, string)"/> or
+        /// <see cref="SpaceServiceProvider.GetAsync(SpaceTypeEnum?, int?, int?, string)"/> instead.
         /// </remarks>
         /// <param name="type">Optional type ID belonging to SpaceTypeEnum.</param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <exception cref="MetasysHttpParsingException"></exception>
+        [Obsolete("Use SpaceServiceProvider.Get(SpaceTypeEnum?, int?, int?, string) instead.")]
         IEnumerable<MetasysObject> GetSpaces(SpaceTypeEnum? type = null);
         /// <inheritdoc cref="IMetasysClient.GetSpaces(SpaceTypeEnum?)"/>
+        [Obsolete("SpaceServiceProvider.GetAsync(SpaceTypeEnum?, int?, int?, string) instead.")]
         Task<IEnumerable<MetasysObject>> GetSpacesAsync(SpaceTypeEnum? type = null);
 
         // GetSpaceChildren --------------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves the collection of spaces that are located within the specified space.
+        /// <s>Retrieves the collection of spaces that are located within the specified space.</s>
         /// </summary>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Spaces service).
+        /// <b>This method is deprecated.</b> Please use
+        /// <see cref="SpaceServiceProvider.GetChildren(ObjectId)"/> or
+        /// <see cref="SpaceServiceProvider.GetChildrenAsync(ObjectId)"/> instead.
         /// </remarks>
         /// <param name="spaceId">The GUID of the parent space.</param>
+        [Obsolete("Use SpaceServiceProvider.GetChildren(ObjectId) instead.")]
         IEnumerable<MetasysObject> GetSpaceChildren(Guid spaceId);
         /// <inheritdoc cref="IMetasysClient.GetSpaceChildren(Guid)"/>
+        [Obsolete("Use SpaceServiceProvider.GetChildrenAsync(ObjectId) instead.")]
         Task<IEnumerable<MetasysObject>> GetSpaceChildrenAsync(Guid spaceId);
+
 
         // GetSpaceTypes -----------------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves the collection of all spaces types.
+        /// <s>Retrieves the collection of all spaces types.</s>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Spaces service).
+        /// <b>This method is deprecated.</b> Please use
+        /// <see cref="SpaceServiceProvider.GetTypes"/> or
+        /// <see cref="SpaceServiceProvider.GetTypesAsync"/> instead.
         /// </remarks>
         /// </summary>
         IEnumerable<MetasysObjectType> GetSpaceTypes();
@@ -369,40 +381,52 @@ namespace JohnsonControls.Metasys.BasicServices
         #region "EQUIPMENTS" //==========================================================================================================
         // GetEquipment -----------------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves a collection of equipment instances.
+        /// <s>Retrieves a collection of equipment instances.</s>
         /// </summary>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Equipments service).
+        /// <b>This method is deprecated.</b> Please use
+        /// <see cref="EquipmentServiceProvider.Get(int?, int?)"/> or
+        /// <see cref="EquipmentServiceProvider.GetAsync(int?, int?)"/> instead.
         /// </remarks>
+        [Obsolete("Use EquipmentServiceProvider.Get(int?, int?) instead.")]
         IEnumerable<MetasysObject> GetEquipment();
         /// <inheritdoc cref="IMetasysClient.GetEquipment()"/>
+        [Obsolete("Use EquipmentServiceProvider.GetAsync(int?, int?) instead.")]
         Task<IEnumerable<MetasysObject>> GetEquipmentAsync();
 
         // GetEquipmentPoints -----------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves the collection of points that are defined by the specified equipment instance
+        /// <s>Retrieves the collection of points that are defined by the specified equipment instance</s>
         /// </summary>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Equipments service).
+        /// <b>This method is deprecated</b> Please use
+        /// <see cref="EquipmentServiceProvider.GetPoints(ObjectId, bool)"/> or
+        /// <see cref="EquipmentServiceProvider.GetPointsAsync(ObjectId, bool)"/> instead.
         /// </remarks>
         /// <param name="equipmentId">The Guid of the equipment.</param>
         /// <param name="readAttributeValue">Set to false if you would not read Points Attribute Value.</param>
         /// <remarks> Reading the Attribute Value attribute could take time depending on the number of points. </remarks>
         /// <returns></returns>
+        [Obsolete("Use EquipmentServiceProvider.GetPoints(ObjectId, bool) instead.")]
         IEnumerable<MetasysPoint> GetEquipmentPoints(Guid equipmentId, bool readAttributeValue = true);
         /// <inheritdoc cref="IMetasysClient.GetEquipmentPoints(Guid, bool)"/>
+        [Obsolete("Use EquipmentServiceProvider.GetPointsAsync(ObjectId, bool) instead.")]
         Task<IEnumerable<MetasysPoint>> GetEquipmentPointsAsync(Guid equipmentId, bool readAttributeValue = true);
 
         // GetSpaceEquipment ------------------------------------------------------------------------------------------------------------
         /// <summary>
-        /// Retrieves the collection of equipment that serve the specified space.
+        /// <s>Retrieves the collection of equipment that serve the specified space.</s>
         /// </summary>
         /// <remarks>
-        /// This method is deprecated (use the corresponding one in Equipments service).
+        /// <b>This method is deprecated</b> Please use
+        /// <see cref="EquipmentServiceProvider.GetServingASpace(ObjectId)"/> or
+        /// <see cref="EquipmentServiceProvider.GetServingASpaceAsync(ObjectId)"/> instead.
         /// </remarks>
         /// <param name="spaceId"></param>
+        [Obsolete("Use EquipmentServiceProvider.GetServingASpace(ObjectId) instead.")]
         IEnumerable<MetasysObject> GetSpaceEquipment(Guid spaceId);
         /// <inheritdoc cref="IMetasysClient.GetSpaceEquipment(Guid)"/>
+        [Obsolete("Use EquipmentServiceProvider.GetServingASpaceAsync(ObjectId) instead.")]
         Task<IEnumerable<MetasysObject>> GetSpaceEquipmentAsync(Guid spaceId);
         #endregion
 
@@ -429,7 +453,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
         /// <summary>
         /// Send an HTTP request as an asynchronous operation.
-        /// 
+        ///
         /// <para>
         /// This method currently only supports 1 value per header rather than multiple. In a future revision, this is planned to be addressed.
         /// </para>
@@ -439,5 +463,66 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead, CancellationToken cancellationToken = default);
+
+        // Deprecated Methods ===========================================================================================
+        #region Deprecated Methods due to Guid -> ObjectId change
+        /// <summary>
+        /// <s>Read many attribute values given the Guids of the objects.</s>
+        /// </summary>
+        /// <remarks>
+        /// This method is deprecated. Please use <see cref="ReadPropertyMultiple(IEnumerable{ObjectId}, IEnumerable{string})"/>
+        /// or <see cref="ReadPropertyMultipleAsync(IEnumerable{ObjectId}, IEnumerable{string})"/> instead.
+        /// </remarks>
+        /// <returns>
+        /// A list of VariantMultiple with all the specified attributes (if existing).
+        /// </returns>
+        /// <param name="ids"></param>
+        /// <param name="attributeNames"></param>
+        /// <exception cref="MetasysHttpException"></exception>
+        /// <exception cref="MetasysPropertyException"></exception>
+        [Obsolete("Use ReadPropertyMultiple(IEnumerable<ObjectId>, IEnumerable<string>) instead.")]
+        IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<Guid> ids, IEnumerable<string> attributeNames);
+        /// <inheritdoc cref="IMetasysClient.ReadPropertyMultiple(IEnumerable{Guid}, IEnumerable{string})"/>
+        [Obsolete("Use ReadPropertyMultipleAsync(IEnumerable<ObjectId>, IEnumerable<string>) instead.")]
+        Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<string> attributeNames);
+
+
+        /// <summary>
+        /// <s>Write to many attribute values given the Guids of the objects.</s>
+        /// </summary>
+        /// <remarks>
+        /// <b>This method is deprecated.</b> Please use one of the following instead:
+        /// <see cref="WritePropertyMultiple(IEnumerable{ObjectId}, Dictionary{string, object})"/>,
+        /// <see cref="WritePropertyMultiple(IEnumerable{ObjectId}, IEnumerable{ValueTuple{string, object}})"/>,
+        /// <see cref="WritePropertyMultipleAsync(IEnumerable{ObjectId}, Dictionary{string, object})"/>,
+        /// or <see cref="WritePropertyMultipleAsync(IEnumerable{ObjectId}, IEnumerable{ValueTuple{string, object}})"/>.
+        /// </remarks>
+        /// <param name="ids"></param>
+        /// <param name="attributeValues">The (attribute, value) pairs.</param>
+        /// <exception cref="MetasysHttpException"></exception>
+        [Obsolete("Use WritePropertyMultiple(IEnumerable<ObjectId>, IEnumerable<string, object>) instead.")]
+        void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
+        /// <inheritdoc cref="WritePropertyMultiple(IEnumerable{Guid}, IEnumerable{ValueTuple{string, object}})"/>
+        [Obsolete("Use WritePropertyMultiple(IEnumerable<ObjectId>, Dictionary<string, object>) instead.")]
+        void WritePropertyMultiple(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues);
+
+        /// <summary>
+        /// <s>Write asynchronously to many attribute values given the Guids of the objects.</s>
+        /// </summary>
+        /// <remarks>
+        /// <b>This method is deprecated.</b> Please use
+        /// <see cref="WritePropertyMultipleAsync(IEnumerable{ObjectId}, Dictionary{string, object})"/> or
+        /// <see cref="WritePropertyMultipleAsync(IEnumerable{ObjectId}, IEnumerable{ValueTuple{string, object}})"/>
+        /// instead.
+        /// </remarks>
+        [Obsolete("Use WritePropertyMultipleAsync(IEnumerable<ObjectId>, IEnumerable<string, object>) instead.")]
+        Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues);
+        /// <inheritdoc cref="IMetasysClient.WritePropertyMultiple(IEnumerable{Guid}, Dictionary{string, object})"/>
+        [Obsolete("Use WritePropertyMultiple(IEnumerable<ObjectId>, Dictionary<string, object>) instead.")]
+        Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues);
+
+        #endregion
+
+
     }
 }

--- a/MetasysServices/MetasysClient.cs
+++ b/MetasysServices/MetasysClient.cs
@@ -28,7 +28,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Stores retrieved Ids and serves as an in-memory caching layer.
         /// </summary>
-        protected Dictionary<string, Guid> IdentifiersDictionary = new Dictionary<string, Guid>();
+        protected Dictionary<string, ObjectId> IdentifiersDictionary = new Dictionary<string, ObjectId>();
 
         /// <inheritdoc/>
         public IActivityService Activities { get; set; }
@@ -325,7 +325,7 @@ namespace JohnsonControls.Metasys.BasicServices
                 var response = await Client.Request("refreshToken")
                                                     .GetJsonAsync<JToken>()
                                                     .ConfigureAwait(false);
-                // Since it's a refresh, get issue info from the current token                
+                // Since it's a refresh, get issue info from the current token
                 CreateAccessToken(AccessToken.Issuer, AccessToken.IssuedTo, response);
                 // Set the new value of the Token to the StreamClient
                 if (Streams != null)
@@ -488,14 +488,15 @@ namespace JohnsonControls.Metasys.BasicServices
 
 
         #region "OBJECTS" // ========================================================================================================
+
         // GetObjects ---------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetObjects(Guid id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false)
+        public IEnumerable<MetasysObject> GetObjects(ObjectId id, int levels = 1, bool includeInternalObjects = false, bool includeExtensions = false)
         {
             return GetObjectsAsync(id, levels, includeInternalObjects, includeExtensions).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetObjectsAsync(Guid id, int levels, bool includeInternalObjects = false, bool includeExtensions = false)
+        public async Task<IEnumerable<MetasysObject>> GetObjectsAsync(ObjectId id, int levels, bool includeInternalObjects = false, bool includeExtensions = false)
         {
             Dictionary<string, string> parameters = null;
             if (Version == ApiVersion.v3)
@@ -528,12 +529,12 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetObjects(Guid id, string objectType)
+        public IEnumerable<MetasysObject> GetObjects(ObjectId id, string objectType)
         {
             return GetObjectsAsync(id, objectType).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetObjectsAsync(Guid objectId, string objectType)
+        public async Task<IEnumerable<MetasysObject>> GetObjectsAsync(ObjectId objectId, string objectType)
         {
             Dictionary<string, string> parameters = null;
 
@@ -555,16 +556,16 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetObjectIdentifier ------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public Guid GetObjectIdentifier(string itemReference)
+        public ObjectId GetObjectIdentifier(string itemReference)
         {
             return GetObjectIdentifierAsync(itemReference).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<Guid> GetObjectIdentifierAsync(string itemReference)
+        public async Task<ObjectId> GetObjectIdentifierAsync(string itemReference)
         {
             // Sanitize given itemReference
             var normalizedItemReference = itemReference.Trim().ToUpper();
-            // Returns cached value when available, otherwise perform request         
+            // Returns cached value when available, otherwise perform request
             if (!IdentifiersDictionary.ContainsKey(normalizedItemReference))
             {
                 JToken response = null;
@@ -593,12 +594,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetCommands --------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<Command> GetCommands(Guid id)
+        public IEnumerable<Command> GetCommands(ObjectId id)
         {
             return GetCommandsAsync(id).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<Command>> GetCommandsAsync(Guid id)
+        public async Task<IEnumerable<Command>> GetCommandsAsync(ObjectId id)
         {
             try
             {
@@ -658,12 +659,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // ReadProperty -------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public Variant ReadProperty(Guid id, string attributeName)
+        public Variant ReadProperty(ObjectId id, string attributeName)
         {
             return ReadPropertyAsync(id, attributeName).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<Variant> ReadPropertyAsync(Guid id, string attributeName)
+        public async Task<Variant> ReadPropertyAsync(ObjectId id, string attributeName)
         {
             JToken response = null; Variant result = new Variant();
             try
@@ -687,12 +688,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // ReadPropertyMultiple -----------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<Guid> ids, IEnumerable<string> attributeNames)
+        public IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<ObjectId> ids, IEnumerable<string> attributeNames)
         {
             return ReadPropertyMultipleAsync(ids, attributeNames).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<string> attributeNames)
+        public async Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<ObjectId> ids, IEnumerable<string> attributeNames)
         {
             if (ids == null || attributeNames == null)
             {
@@ -739,12 +740,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // WriteProperty ------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public void WriteProperty(Guid id, string attributeName, object newValue)
+        public void WriteProperty(ObjectId id, string attributeName, object newValue)
         {
             WritePropertyAsync(id, attributeName, newValue).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task WritePropertyAsync(Guid id, string attributeName, object newValue)
+        public async Task WritePropertyAsync(ObjectId id, string attributeName, object newValue)
         {
             List<(string Attribute, object Value)> list = new List<(string Attribute, object Value)>
             {
@@ -756,12 +757,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // WritePropertyMultiple ----------------------------------------------------------------------------------------------------
         ///<inheritdoc/>
-        public void WritePropertyMultiple(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues)
+        public void WritePropertyMultiple(IEnumerable<ObjectId> ids, Dictionary<string, object> attributeValues)
         {
             WritePropertyMultipleAsync(ids, attributeValues).GetAwaiter().GetResult();
         }
         ///<inheritdoc/>
-        public async Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues)
+        public async Task WritePropertyMultipleAsync(IEnumerable<ObjectId> ids, Dictionary<string, object> attributeValues)
         {
             if (ids == null || attributeValues == null)
             {
@@ -773,12 +774,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // WritePropertyMultiple (2) ------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
+        public void WritePropertyMultiple(IEnumerable<ObjectId> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
         {
             WritePropertyMultipleAsync(ids, attributeValues).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
+        public async Task WritePropertyMultipleAsync(IEnumerable<ObjectId> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
         {
             if (ids == null || attributeValues == null)
             {
@@ -797,12 +798,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // SendCommand --------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public void SendCommand(Guid id, string command, IEnumerable<object> values = null)
+        public void SendCommand(ObjectId id, string command, IEnumerable<object> values = null)
         {
             SendCommandAsync(id, command, values).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task SendCommandAsync(Guid id, string command, IEnumerable<object> values = null)
+        public async Task SendCommandAsync(ObjectId id, string command, IEnumerable<object> values = null)
         {
             if (values == null)
             {
@@ -957,7 +958,7 @@ namespace JohnsonControls.Metasys.BasicServices
         //{
         //    DateTime now = DateTime.UtcNow;
         //    TimeSpan delay = AccessToken.Expires - now.AddSeconds(-1); // minimum renew gap of 1 sec in advance
-        //    // Renew one minute before expiration if there is more than one minute time 
+        //    // Renew one minute before expiration if there is more than one minute time
         //    if (delay > new TimeSpan(0, 1, 0))
         //    {
         //        delay.Subtract(new TimeSpan(0, 1, 0));
@@ -982,13 +983,13 @@ namespace JohnsonControls.Metasys.BasicServices
 
 
         /// <summary>
-        /// Overload of ReadPropertyAsync for internal use where Exception suppress is needed, e.g. ReadPropertyMultiple 
+        /// Overload of ReadPropertyAsync for internal use where Exception suppress is needed, e.g. ReadPropertyMultiple
         /// </summary>
         /// <param name="id"></param>
         /// <param name="attributeName"></param>
         /// <param name="suppressNotFoundException"></param>
         /// <returns></returns>
-        private async Task<Variant> ReadPropertyAsync(Guid id, string attributeName, bool suppressNotFoundException = true)
+        private async Task<Variant> ReadPropertyAsync(ObjectId id, string attributeName, bool suppressNotFoundException = true)
         {
             try
             {
@@ -1003,7 +1004,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Creates the body for the WriteProperty and WritePropertyMultiple requests as a dictionary.
         /// </summary>
-        /// <param name="attributeValues">The (attribute, value) pairs.</param>      
+        /// <param name="attributeValues">The (attribute, value) pairs.</param>
         /// <returns>Dictionary of the attribute, value pairs.</returns>
         private Dictionary<string, object> GetWritePropertyBody(IEnumerable<(string Attribute, object Value)> attributeValues)
         {
@@ -1022,7 +1023,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="body"></param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <returns>Asynchronous Task Result.</returns>
-        private async Task WritePropertyRequestAsync(Guid id, Dictionary<string, object> body)
+        private async Task WritePropertyRequestAsync(ObjectId id, Dictionary<string, object> body)
         {
             var json = new { item = body };
 
@@ -1040,7 +1041,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         ///// <summary>
-        ///// Gets the type from a token retrieved from a typeUrl 
+        ///// Gets the type from a token retrieved from a typeUrl
         ///// </summary>
         ///// <param name="typeToken"></param>
         ///// <exception cref="MetasysHttpException"></exception>
@@ -1134,7 +1135,7 @@ namespace JohnsonControls.Metasys.BasicServices
             foreach (var r in response["responses"])
             {
                 var respIds = r["id"].Value<string>().Split('_');
-                var objId = new Guid(respIds[0]);
+                var objId = new ObjectId(respIds[0]);
                 string attr = respIds[1];
                 List<Variant> values = new List<Variant>();
                 if (r["status"].Value<int>() == 200)
@@ -1144,7 +1145,7 @@ namespace JohnsonControls.Metasys.BasicServices
                 var m = multiples.SingleOrDefault(s => s.Id == objId);
                 if (m == null)
                 {
-                    // Add a new multiple for the current object                   
+                    // Add a new multiple for the current object
                     multiples.Add(new VariantMultiple(objId, values));
                 }
                 else
@@ -1166,7 +1167,7 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="values"></param>
         /// <exception cref="MetasysHttpException"></exception>
         /// <returns>Asynchronous Task Result.</returns>
-        private async Task SendCommandRequestAsync(Guid id, string command, IEnumerable<object> values)
+        private async Task SendCommandRequestAsync(ObjectId id, string command, IEnumerable<object> values)
         {
             try
             {
@@ -1238,7 +1239,52 @@ namespace JohnsonControls.Metasys.BasicServices
             }
         }
         #endregion
+
+        #region Deprecated Methods Due to Guid -> ObjectId
+        // ReadPropertyMultiple -----------------------------------------------------------------------------------------------------
+        /// <inheritdoc/>
+        [Obsolete("Use ReadPropertyMultiple(IEnumerable<ObjectId>, IEnumerable<string>) instead.")]
+        public IEnumerable<VariantMultiple> ReadPropertyMultiple(IEnumerable<Guid> ids, IEnumerable<string> attributeNames)
+        {
+            return ReadPropertyMultipleAsync(ids, attributeNames).GetAwaiter().GetResult();
+        }
+        /// <inheritdoc/>
+        [Obsolete("Use ReadPropertyMultipleAsync(IEnumerable<ObjectId>, IEnumerable<string>) instead.")]
+        public Task<IEnumerable<VariantMultiple>> ReadPropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<string> attributeNames)
+        {
+            return ReadPropertyMultipleAsync(ids.Cast<ObjectId>(), attributeNames);
+        }
+
+        // WritePropertyMultiple ----------------------------------------------------------------------------------------------------
+        ///<inheritdoc/>
+        [Obsolete("Use WritePropertyMultiple(IEnumerable<ObjectId>, Dictionary<string, object>) instead.")]
+        public void WritePropertyMultiple(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues)
+        {
+            WritePropertyMultipleAsync(ids, attributeValues).GetAwaiter().GetResult();
+        }
+        ///<inheritdoc/>
+        [Obsolete("Use WritePropertyMultipleAsync(IEnumerable<ObjectId>, Dictionary<string, object>) instead.")]
+        public Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, Dictionary<string, object> attributeValues)
+        {
+            return WritePropertyMultipleAsync(ids.Cast<ObjectId>(), attributeValues);
+        }
+
+        // WritePropertyMultiple (2) ------------------------------------------------------------------------------------------------
+
+        /// <inheritdoc/>
+        [Obsolete("Use WritePropertyMultiple(IEnumerable<ObjectId> ids, IEnumerable<ValueTuple<string, Value>>) instead.")]
+        public void WritePropertyMultiple(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
+        {
+            WritePropertyMultipleAsync(ids, attributeValues).GetAwaiter().GetResult();
+        }
+        /// <inheritdoc/>
+        [Obsolete("Use WritePropertyMultipleAsync(IEnumerable<ObjectId> ids, IEnumerable<ValueTuple<string, Value>>) instead.")]
+        public Task WritePropertyMultipleAsync(IEnumerable<Guid> ids, IEnumerable<(string Attribute, object Value)> attributeValues)
+        {
+            return WritePropertyMultipleAsync(ids.Cast<ObjectId>(), attributeValues);
+        }
+
+        #endregion
     }
 
 }
-

--- a/MetasysServices/MetasysServices.csproj
+++ b/MetasysServices/MetasysServices.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"> 
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>JohnsonControls.Metasys.BasicServices</RootNamespace>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>12</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>© 2020-2024 Johnson Controls</Copyright>
     <Company>Johnson Controls Int.</Company>
@@ -17,8 +17,8 @@
 - Updated the dictionaries of all the supported locales
 - Cleaned up unnecessary code</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>6.0.4</Version>    
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Version>6.0.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -48,7 +48,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-	<None Include="..\README.md">
+    <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
@@ -67,7 +67,7 @@
   <ItemGroup>
     <Content Include="..\README.md">
       <Link>README.md</Link>
-    </Content>   
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/MetasysServices/Models/BatchRequestParam.cs
+++ b/MetasysServices/Models/BatchRequestParam.cs
@@ -11,7 +11,7 @@ namespace JohnsonControls.Metasys.BasicServices
     public class BatchRequestParam
     {
         /// <summary> Id to identify the object </summary>
-        public Guid ObjectId { get; set; }
+        public ObjectId ObjectId { get; set; }
 
         /// <summary> String that could represent a text resource as, for instance, a text annotation </summary>
         public string Resource { get; set; }

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -18,7 +18,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
         /// <summary>The id of the Metasys object.</summary>
         [JsonProperty(Required = Required.Always)]
-        public Guid Id { set; get; }
+        public ObjectId Id { set; get; }
 
         /// <summary>The name of the Metasys object.</summary>
         [JsonProperty(Required = Required.Always)]
@@ -33,13 +33,13 @@ namespace JohnsonControls.Metasys.BasicServices
         public MetasysObjectTypeEnum? Type { get; set; }
 
         /// <summary>
-        /// The resource type detail reference. 
+        /// The resource type detail reference.
         /// </summary>
         /// <remarks> This is available only on Metasys API v2 and v1. </remarks>
         public string TypeUrl { get; set; }
 
         /// <summary>
-        /// The resource type detail reference. 
+        /// The resource type detail reference.
         /// </summary>
         /// <remarks> This is available since Metasys API v3. </remarks>
         public string ObjectType { get; set; }
@@ -86,8 +86,8 @@ namespace JohnsonControls.Metasys.BasicServices
 
         internal MetasysObject(JToken token, ApiVersion version, IEnumerable<MetasysObject> children = null, MetasysObjectTypeEnum? type = null)
         {
-            Children = children ?? new List<MetasysObject>(); // Return empty list by convention for null         
-            ChildrenCount = Children?.Count() ?? 0; // Children count is 0 when children is null                                 
+            Children = children ?? new List<MetasysObject>(); // Return empty list by convention for null
+            ChildrenCount = Children?.Count() ?? 0; // Children count is 0 when children is null
             Type = type;
 
             JObject jobj = token.ToObject<JObject>();
@@ -153,7 +153,7 @@ namespace JohnsonControls.Metasys.BasicServices
             {
                 try
                 {
-                    // Object Type is available since API v3 only on object detail. 
+                    // Object Type is available since API v3 only on object detail.
                     ObjectType = jobj.ContainsKey("objectType") ? token["objectType"].Value<string>() : null;
                 }
                 catch

--- a/MetasysServices/Models/ObjectId.cs
+++ b/MetasysServices/Models/ObjectId.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Security.Policy;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+
+    /// <summary>
+    /// A Metasys Object Identifier
+    /// </summary>
+    /// <remarks>
+    /// Wherever an ObjectId is required you can pass a string instead.
+    ///
+    /// This is because this is just a token type to signify that an object identifier is required.
+    /// As such it has implicit conversions to/from string.
+    /// </remarks>
+    public record struct ObjectId(string Value) : IEquatable<ObjectId>, IEquatable<string>, IEquatable<Guid>
+    {
+
+        /// <summary>
+        /// Creates a default instance of <see cref="ObjectId"/> that is synonymous
+        /// with an empty string.
+        /// </summary>
+        public ObjectId() : this("")
+        {
+        }
+
+        /// <summary>
+        /// Implicitly convert an <see cref="ObjectId"/> to <see cref="string"/>
+        /// </summary>
+        /// <param name="objectId"></param>
+        public static implicit operator string(ObjectId objectId)
+        {
+            return objectId.Value;
+        }
+
+        /// <summary>
+        /// Implicitly convert a <see cref="string"/> to <see cref="ObjectId"/>
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ObjectId(string value)
+        {
+            return new ObjectId(value);
+        }
+
+        /// <summary>
+        /// Implicitly convert a <see cref="Guid"/> to <see cref="ObjectId"/>
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ObjectId(Guid value)
+        {
+            return new ObjectId(value.ToString());
+        }
+
+        /// <summary>
+        /// <s>Implicitly convert a <see cref="ObjectId"/> to <see cref="Guid"/></s>
+        /// </summary>
+        /// <remarks>
+        /// <b>This method is deprecated.</b> This method is not guaranteed to always succeed
+        /// in the future. While Metasys object identifiers have always safely converted to Guids
+        /// they make no guarantee that they will always. Nor does the REST API spec document
+        /// them as Guids.
+        /// <para>
+        /// To avoid issues, use methods from this library that take an <see cref="ObjectId"/> for
+        /// object identifiers. You can even pass strings to those methods as strings will implicitly
+        /// convert to ObjectId.
+        /// </para>
+        /// </remarks>
+        /// <param name="objectId"></param>
+        // As of writing this should never throw as Metasys currently uses
+        // guids for identifiers. But it doesn't advertise this and doesn't
+        // guarantee it. Which is why the Guid operators have been deprecated
+        // and why this class was created.
+        // This operator is as safe as using Guids in all of the demo apps
+        // today. Any one of them could throw if an object id was goofed up.
+        [Obsolete("This is not guaranteed to always succeed. Please use methods that use strings or ObjectIds for object identifiers instead.")]
+        public static implicit operator Guid(ObjectId objectId)
+        {
+            if (Guid.TryParse(objectId, out Guid value))
+            {
+                return value;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(objectId), "Value must contain a valid guid.");
+        }
+
+        /// <inheritdoc cref="object.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /// <inheritdoc cref="object.ToString"/>
+        public override string ToString()
+        {
+            return Value;
+        }
+
+
+        /// <inheritdoc cref="IEquatable{T}"/>
+        public bool Equals(ObjectId other)
+        {
+            return Value == other.Value;
+        }
+
+        /// <inheritdoc cref="IEquatable{T}"/>
+        public bool Equals(string other)
+        {
+            return Value == other;
+        }
+
+        /// <inheritdoc cref="object.Equals(object)"/>
+        public bool Equals(Guid other)
+        {
+            return other.ToString() == Value;
+        }
+
+    }
+}

--- a/MetasysServices/Models/Variant.cs
+++ b/MetasysServices/Models/Variant.cs
@@ -11,7 +11,7 @@ namespace JohnsonControls.Metasys.BasicServices
     /// value from a single Metasys object.
     /// </summary>
     /// <remarks>
-    /// If the returned property is an array of values the ArrayValue will hold 
+    /// If the returned property is an array of values the ArrayValue will hold
     /// each of these values in a new Variant object.
     /// </remarks>
     public class Variant
@@ -37,7 +37,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
         /// <summary>The enumeration key of the StringValue.</summary>
         /// <value>
-        /// The pre-translated StringValue as an enumeration key or the StringValue if it 
+        /// The pre-translated StringValue as an enumeration key or the StringValue if it
         /// was not an enumeration key. Null if value is not a string, array, or unsupported type.
         /// </value>
         public string StringValueEnumerationKey { private set; get; }
@@ -70,7 +70,7 @@ namespace JohnsonControls.Metasys.BasicServices
         public string Attribute { private set; get; }
 
         /// <summary>The id of the Metasys object.</summary>
-        public Guid Id { private set; get; }
+        public ObjectId Id { private set; get; }
 
         /// <summary>The reliability of the value.</summary>
         /// <value>
@@ -105,7 +105,7 @@ namespace JohnsonControls.Metasys.BasicServices
         public bool IsReliable => ReliabilityEnumerationKey == Reliable;
 
         /// <summary>
-        /// The Metasys API version taken as a reference to process the JToken. 
+        /// The Metasys API version taken as a reference to process the JToken.
         /// </summary>
         private ApiVersion apiVersion;
 
@@ -115,7 +115,7 @@ namespace JohnsonControls.Metasys.BasicServices
         {
         }
 
-        internal Variant(Guid id, JToken token, string attribute, CultureInfo cultureInfo, ApiVersion apiVersion)
+        internal Variant(ObjectId id, JToken token, string attribute, CultureInfo cultureInfo, ApiVersion apiVersion)
         {
             this.apiVersion = apiVersion;
             _CultureInfo = cultureInfo;

--- a/MetasysServices/Models/VariantMultiple.cs
+++ b/MetasysServices/Models/VariantMultiple.cs
@@ -12,12 +12,12 @@ namespace JohnsonControls.Metasys.BasicServices
     public class VariantMultiple
     {
         /// <summary>The object id.</summary>
-        public Guid Id { private set; get; }
+        public ObjectId Id { private set; get; }
 
         /// <summary>The list of Variants.</summary>
         public IEnumerable<Variant> Values { set; get; }
 
-        internal VariantMultiple(Guid id, IEnumerable<Variant> values)
+        internal VariantMultiple(ObjectId id, IEnumerable<Variant> values)
         {
             Id = id;
             Values = values;

--- a/MetasysServices/Spaces/ISpaceService.cs
+++ b/MetasysServices/Spaces/ISpaceService.cs
@@ -17,9 +17,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="spaceId">The identifier of the space.</param>
         /// <returns>The specified alarm details.</returns>
-        MetasysObject FindById(Guid spaceId);
-        /// <inheritdoc cref="ISpaceService.FindById(Guid)"/>
-        Task<MetasysObject> FindByIdAsync(Guid spaceId);
+        MetasysObject FindById(ObjectId spaceId);
+        /// <inheritdoc cref="ISpaceService.FindById(ObjectId)"/>
+        Task<MetasysObject> FindByIdAsync(ObjectId spaceId);
+
 
         // Get ---------------------------------------------------------------------------------------------------------------------
         /// <summary>
@@ -52,10 +53,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Retrieves the collection of spaces that are located within the specified space.
         /// </summary>
-        /// <param name="spaceId">The GUID of the parent space.</param>
-        IEnumerable<MetasysObject> GetChildren(Guid spaceId);
-        /// <inheritdoc cref="ISpaceService.GetChildren(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetChildrenAsync(Guid spaceId);
+        /// <param name="spaceId">The id of the parent space.</param>
+        IEnumerable<MetasysObject> GetChildren(ObjectId spaceId);
+        /// <inheritdoc cref="ISpaceService.GetChildren(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetChildrenAsync(ObjectId spaceId);
 
         // GetSpaceTypes -----------------------------------------------------------------------------------------------------------------
         /// <summary>
@@ -69,17 +70,17 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// Retrieves the collection of spaces served by the specified network device.
         /// </summary>
-        IEnumerable<MetasysObject> GetServedByNetworkDevice(Guid networkDeviceId);
-        /// <inheritdoc cref="ISpaceService.GetServedByNetworkDevice(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetServedByNetworkDeviceAsync(Guid networkDeviceId);
+        IEnumerable<MetasysObject> GetServedByNetworkDevice(ObjectId networkDeviceId);
+        /// <inheritdoc cref="ISpaceService.GetServedByNetworkDevice(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetServedByNetworkDeviceAsync(ObjectId networkDeviceId);
 
         // GetServedByEquipment ----------------------------------------------------------------------------------------------------------
         /// <summary>
         /// Retrieves the collection of spaces served by the specified network device.
         /// </summary>
-        IEnumerable<MetasysObject> GetServedByEquipment(Guid equipmentId);
-        /// <inheritdoc cref="ISpaceService.GetServedByEquipment(Guid)"/>
-        Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(Guid equipmentId);
+        IEnumerable<MetasysObject> GetServedByEquipment(ObjectId equipmentId);
+        /// <inheritdoc cref="ISpaceService.GetServedByEquipment(ObjectId)"/>
+        Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(ObjectId equipmentId);
 
     }
 }

--- a/MetasysServices/Spaces/SpaceServiceProvider.cs
+++ b/MetasysServices/Spaces/SpaceServiceProvider.cs
@@ -32,17 +32,19 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // FindById -------------------------------------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public MetasysObject FindById(Guid spaceId)
+        public MetasysObject FindById(ObjectId spaceId)
         {
             return FindByIdAsync(spaceId).GetAwaiter().GetResult();
         }
+
         /// <inheritdoc/>
-        public async Task<MetasysObject> FindByIdAsync(Guid spaceId)
+        public async Task<MetasysObject> FindByIdAsync(ObjectId spaceId)
         {
             CheckVersion(Version);
             var response = await GetRequestAsync("spaces", null, spaceId).ConfigureAwait(false);
             return ToMetasysObject(response, Version, MetasysObjectTypeEnum.Space);
         }
+
 
         // Get ---------------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
@@ -89,12 +91,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetChildren ------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetChildren(Guid spaceId)
+        public IEnumerable<MetasysObject> GetChildren(ObjectId spaceId)
         {
             return GetChildrenAsync(spaceId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetChildrenAsync(Guid spaceId)
+        public async Task<IEnumerable<MetasysObject>> GetChildrenAsync(ObjectId spaceId)
         {
             CheckVersion(Version);
             var spaceChildren = await GetAllAvailablePagesAsync("spaces", null, spaceId.ToString(), "spaces").ConfigureAwait(false);
@@ -122,12 +124,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetServedByEquipment ------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetServedByEquipment(Guid equipmentId)
+        public IEnumerable<MetasysObject> GetServedByEquipment(ObjectId equipmentId)
         {
             return GetServedByEquipmentAsync(equipmentId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(Guid equipmentId)
+        public async Task<IEnumerable<MetasysObject>> GetServedByEquipmentAsync(ObjectId equipmentId)
         {
             CheckVersion(Version);
             var response = await GetAllAvailablePagesAsync("equipment", null, equipmentId.ToString(), "spaces").ConfigureAwait(false);
@@ -136,16 +138,17 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetServedByNetworkDevice ------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public IEnumerable<MetasysObject> GetServedByNetworkDevice(Guid networkDeviceId)
+        public IEnumerable<MetasysObject> GetServedByNetworkDevice(ObjectId networkDeviceId)
         {
             return GetServedByNetworkDeviceAsync(networkDeviceId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<IEnumerable<MetasysObject>> GetServedByNetworkDeviceAsync(Guid networkDeviceId)
+        public async Task<IEnumerable<MetasysObject>> GetServedByNetworkDeviceAsync(ObjectId networkDeviceId)
         {
             CheckVersion(Version);
             var response = await GetAllAvailablePagesAsync("networkDevices", null, networkDeviceId.ToString(), "spaces").ConfigureAwait(false);
             return ToMetasysObject(response, Version, MetasysObjectTypeEnum.Space);
         }
+
     }
 }

--- a/MetasysServices/Trends/ITrendService.cs
+++ b/MetasysServices/Trends/ITrendService.cs
@@ -2,18 +2,19 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using JohnsonControls.Metasys.BasicServices.Utils;
 
 namespace JohnsonControls.Metasys.BasicServices
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface ITrendService : IBasicService
     {
         /// <summary>
         /// Get the list of trended attributes for the given object.
-        /// </summary>    
-        /// <param name="id">The indentifier (GUID) of the object.</param>
+        /// </summary>
+        /// <param name="id">The identifier of the object.</param>
         /// <returns>The list of trended attributes.</returns>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysHttpException"></exception>
@@ -21,15 +22,15 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        List<MetasysAttribute> GetTrendedAttributes(Guid id);
-        /// <inheritdoc cref="ITrendService.GetTrendedAttributes(Guid)"/>
-        Task<List<MetasysAttribute>> GetTrendedAttributesAsync(Guid id);
+        List<MetasysAttribute> GetTrendedAttributes(ObjectId id);
+        /// <inheritdoc cref="ITrendService.GetTrendedAttributes(ObjectId)"/>
+        Task<List<MetasysAttribute>> GetTrendedAttributesAsync(ObjectId id);
 
         /// <summary>
         /// Retrieves available samples for the given object attribute, filtered by startTime and endTime.
         /// </summary>
         /// <remarks>StartTime and EndTime are mandatory parameters.</remarks>
-        /// <param name="objectId">The identifier (GUID) of the object.</param>
+        /// <param name="objectId">The identifier of the object.</param>
         /// <param name="attributeId">The numeric identifier of the attribute.</param>
         /// <param name="filter">The filter that specifies: startTime, endTime, page, pageSize, sort.</param>
         /// <returns>The list of samples.</returns>
@@ -39,15 +40,15 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        PagedResult<Sample> GetSamples(Guid objectId, int attributeId, TimeFilter filter);
-        /// <inheritdoc cref="ITrendService.GetSamples(Guid, int, TimeFilter)"/>
-        Task<PagedResult<Sample>> GetSamplesAsync(Guid objectId, int attributeId, TimeFilter filter);
+        PagedResult<Sample> GetSamples(ObjectId objectId, int attributeId, TimeFilter filter);
+        /// <inheritdoc cref="ITrendService.GetSamples(ObjectId, int, TimeFilter)"/>
+        Task<PagedResult<Sample>> GetSamplesAsync(ObjectId objectId, int attributeId, TimeFilter filter);
 
         /// <summary>
         /// Retrieves available samples for the given object attribute, filtered by startTime and endTime.
         /// </summary>
         /// <remarks>StartTime and EndTime are mandatory parameters.</remarks>
-        /// <param name="objectId">The identifier (GUID) of the object.</param>
+        /// <param name="objectId">The identifier of the object.</param>
         /// <param name="attributeName">The textual identifier of the attribute.</param>
         /// <param name="filter">The filter that specifies: startTime, endTime, page, pageSize, sort.</param>
         /// <returns>The list of samples.</returns>
@@ -57,14 +58,14 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        PagedResult<Sample> GetSamples(Guid objectId, AttributeEnumSet attributeName, TimeFilter filter);
-        /// <inheritdoc cref="ITrendService.GetSamples(Guid, AttributeEnumSet, TimeFilter)"/>
-        Task<PagedResult<Sample>> GetSamplesAsync(Guid objectId, AttributeEnumSet attributeName, TimeFilter filter);
+        PagedResult<Sample> GetSamples(ObjectId objectId, AttributeEnumSet attributeName, TimeFilter filter);
+        /// <inheritdoc cref="ITrendService.GetSamples(ObjectId, AttributeEnumSet, TimeFilter)"/>
+        Task<PagedResult<Sample>> GetSamplesAsync(ObjectId objectId, AttributeEnumSet attributeName, TimeFilter filter);
 
         /// <summary>
         /// Get the list of trended attributes for the given Network Device.
-        /// </summary>    
-        /// <param name="id">The identifier (GUID) of the network device.</param>
+        /// </summary>
+        /// <param name="id">The identifier of the network device.</param>
         /// <returns>The list of trended attributes.</returns>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysHttpException"></exception>
@@ -72,15 +73,15 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        List<MetasysAttribute> GetNetDevTrendedAttributes(Guid id);
-        /// <inheritdoc cref="ITrendService.GetNetDevTrendedAttributes(Guid)"/>
-        Task<List<MetasysAttribute>> GetNetDevTrendedAttributesAsync(Guid id);
+        List<MetasysAttribute> GetNetDevTrendedAttributes(ObjectId id);
+        /// <inheritdoc cref="ITrendService.GetNetDevTrendedAttributes(ObjectId)"/>
+        Task<List<MetasysAttribute>> GetNetDevTrendedAttributesAsync(ObjectId id);
 
         /// <summary>
         /// Retrieves available samples for the given network device attribute, filtered by startTime and endTime.
         /// </summary>
         /// <remarks>StartTime and EndTime are mandatory parameters.</remarks>
-        /// <param name="networkDeviceId">The identifier (GUID) of the network device.</param>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
         /// <param name="attributeId">The numeric identifier of the attribute.</param>
         /// <param name="filter">The filter that specifies: startTime, endTime, page, pageSize, sort.</param>
         /// <returns>The list of samples.</returns>
@@ -90,15 +91,15 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        PagedResult<Sample> GetNetDevSamples(Guid networkDeviceId, int attributeId, TimeFilter filter);
-        /// <inheritdoc cref="ITrendService.GetNetDevSamples(Guid, int, TimeFilter)"/>
-        Task<PagedResult<Sample>> GetNetDevSamplesAsync(Guid networkDeviceId, int attributeId, TimeFilter filter);
+        PagedResult<Sample> GetNetDevSamples(ObjectId networkDeviceId, int attributeId, TimeFilter filter);
+        /// <inheritdoc cref="ITrendService.GetNetDevSamples(ObjectId, int, TimeFilter)"/>
+        Task<PagedResult<Sample>> GetNetDevSamplesAsync(ObjectId networkDeviceId, int attributeId, TimeFilter filter);
 
         /// <summary>
         /// Retrieves available samples for the given network device attribute, filtered by startTime and endTime.
         /// </summary>
         /// <remarks>StartTime and EndTime are mandatory parameters.</remarks>
-        /// <param name="networkDeviceId">The identifier (GUID) of the network device.</param>
+        /// <param name="networkDeviceId">The identifier of the network device.</param>
         /// <param name="attributeName">The textual identifier of the attribute.</param>
         /// <param name="filter">The filter that specifies: startTime, endTime, page, pageSize, sort.</param>
         /// <returns>The list of samples.</returns>
@@ -108,9 +109,9 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <exception cref="MetasysHttpParsingException"></exception>
         /// <exception cref="MetasysHttpNotFoundException"></exception>
         /// <exception cref="MetasysObjectException"></exception>
-        PagedResult<Sample> GetNetDevSamples(Guid networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter);
-        /// <inheritdoc cref="ITrendService.GetNetDevSamples(Guid, AttributeEnumSet, TimeFilter)"/>
-        Task<PagedResult<Sample>> GetNetDevSamplesAsync(Guid networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter);
+        PagedResult<Sample> GetNetDevSamples(ObjectId networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter);
+        /// <inheritdoc cref="ITrendService.GetNetDevSamples(ObjectId, AttributeEnumSet, TimeFilter)"/>
+        Task<PagedResult<Sample>> GetNetDevSamplesAsync(ObjectId networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter);
 
     }
 }

--- a/MetasysServices/Trends/TrendServiceProvider.cs
+++ b/MetasysServices/Trends/TrendServiceProvider.cs
@@ -33,7 +33,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public PagedResult<Sample> GetSamples(Guid objectId, int attributeId, TimeFilter filter)
+        public PagedResult<Sample> GetSamples(ObjectId objectId, int attributeId, TimeFilter filter)
         {
             CheckVersion(Version);
             if (Version > ApiVersion.v3)
@@ -49,7 +49,7 @@ namespace JohnsonControls.Metasys.BasicServices
             }
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Sample>> GetSamplesAsync(Guid objectId, int attributeId, TimeFilter filter)
+        public async Task<PagedResult<Sample>> GetSamplesAsync(ObjectId objectId, int attributeId, TimeFilter filter)
         {
             //Note: this method is valid only for API version v2 and v3
             if (Version < ApiVersion.v2 | Version > ApiVersion.v3) { throw new MetasysUnsupportedApiVersion(Version.ToString()); }
@@ -114,7 +114,7 @@ namespace JohnsonControls.Metasys.BasicServices
             };
         }
         /// <inheritdoc/>
-        public PagedResult<Sample> GetSamples(Guid objectId, AttributeEnumSet attributeName, TimeFilter filter)
+        public PagedResult<Sample> GetSamples(ObjectId objectId, AttributeEnumSet attributeName, TimeFilter filter)
         {
             if (Version > ApiVersion.v3)
             {
@@ -126,7 +126,7 @@ namespace JohnsonControls.Metasys.BasicServices
             }
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Sample>> GetSamplesAsync(Guid objectId, AttributeEnumSet attributeName, TimeFilter filter)
+        public async Task<PagedResult<Sample>> GetSamplesAsync(ObjectId objectId, AttributeEnumSet attributeName, TimeFilter filter)
         {
             //Note: this method is valid for API version > v3
             if (Version < ApiVersion.v4) { throw new MetasysUnsupportedApiVersion(Version.ToString()); }
@@ -166,12 +166,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetTrendedAttributes --------------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public List<MetasysAttribute> GetTrendedAttributes(Guid id)
+        public List<MetasysAttribute> GetTrendedAttributes(ObjectId id)
         {
             return GetTrendedAttributesAsync(id).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<List<MetasysAttribute>> GetTrendedAttributesAsync(Guid id)
+        public async Task<List<MetasysAttribute>> GetTrendedAttributesAsync(ObjectId id)
         {
             CheckVersion(Version);
 
@@ -229,12 +229,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetNetDevTrendedAttributes --------------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public List<MetasysAttribute> GetNetDevTrendedAttributes(Guid id)
+        public List<MetasysAttribute> GetNetDevTrendedAttributes(ObjectId id)
         {
             return GetNetDevTrendedAttributesAsync(id).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<List<MetasysAttribute>> GetNetDevTrendedAttributesAsync(Guid id)
+        public async Task<List<MetasysAttribute>> GetNetDevTrendedAttributesAsync(ObjectId id)
         {
             CheckVersion(Version);
 
@@ -292,7 +292,7 @@ namespace JohnsonControls.Metasys.BasicServices
 
         // GetNetDevSamples
         /// <inheritdoc/>
-        public PagedResult<Sample> GetNetDevSamples(Guid networkDeviceId, int attributeId, TimeFilter filter)
+        public PagedResult<Sample> GetNetDevSamples(ObjectId networkDeviceId, int attributeId, TimeFilter filter)
         {
             if (Version > ApiVersion.v3)
             {
@@ -307,7 +307,7 @@ namespace JohnsonControls.Metasys.BasicServices
             }
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Sample>> GetNetDevSamplesAsync(Guid networkDeviceId, int attributeId, TimeFilter filter)
+        public async Task<PagedResult<Sample>> GetNetDevSamplesAsync(ObjectId networkDeviceId, int attributeId, TimeFilter filter)
         {
             //Note: this method is valid only for API version v2 and v3
             if (Version < ApiVersion.v2 | Version > ApiVersion.v3) { throw new MetasysUnsupportedApiVersion(Version.ToString()); }
@@ -357,7 +357,7 @@ namespace JohnsonControls.Metasys.BasicServices
             };
         }
         /// <inheritdoc/>
-        public PagedResult<Sample> GetNetDevSamples(Guid networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter)
+        public PagedResult<Sample> GetNetDevSamples(ObjectId networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter)
         {
             if (Version > ApiVersion.v3)
             {
@@ -369,7 +369,7 @@ namespace JohnsonControls.Metasys.BasicServices
             }
         }
         /// <inheritdoc/>
-        public async Task<PagedResult<Sample>> GetNetDevSamplesAsync(Guid networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter)
+        public async Task<PagedResult<Sample>> GetNetDevSamplesAsync(ObjectId networkDeviceId, AttributeEnumSet attributeName, TimeFilter filter)
         {
             //Note: this method is valid for API version > v3
             if (Version < ApiVersion.v4) { throw new MetasysUnsupportedApiVersion(Version.ToString()); }
@@ -419,5 +419,6 @@ namespace JohnsonControls.Metasys.BasicServices
                 Total = response.Total
             };
         }
+
     }
 }

--- a/MetasysServicesCom/LegacyMetasysClient.cs
+++ b/MetasysServicesCom/LegacyMetasysClient.cs
@@ -9,6 +9,7 @@ using MetasysAttribute = JohnsonControls.Metasys.BasicServices.MetasysAttribute;
 
 namespace JohnsonControls.Metasys.ComServices
 {
+
     /// <summary>
     /// An COM HTTP client for consuming the most commonly used endpoints of the Metasys API.
     /// </summary>
@@ -561,11 +562,11 @@ namespace JohnsonControls.Metasys.ComServices
             return Mapper.Map<IComMetasysObject[]>(res);
         }
 
-        //GetObjectidentifier -------------------------------------------------------------------------------------------------------
+        //GetObjectIdentifier -------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
         public string GetObjectIdentifier(string itemReference)
         {
-            Guid? res = Client.GetObjectIdentifier(itemReference);
+            ObjectId? res = Client.GetObjectIdentifier(itemReference);
             return res?.ToString();
         }
 
@@ -610,12 +611,7 @@ namespace JohnsonControls.Metasys.ComServices
         {
             // Note: MarshalAs decorator is needed for arrays, otherwise will cause a VBA app crash
             // Note: need a generic object as return type in order to map correctly to VBA type array
-            var guidList = new List<Guid>();
-            foreach (var id in ids)
-            {
-                guidList.Add(new Guid(id));
-            }
-            var res = Client.ReadPropertyMultiple(guidList, attributeNames);
+            var res = Client.ReadPropertyMultiple(ids.Select(id => (ObjectId)id), attributeNames);
             return Mapper.Map<IComVariantMultiple[]>(res);
         }
 
@@ -631,18 +627,13 @@ namespace JohnsonControls.Metasys.ComServices
         public void WritePropertyMultiple([In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] string[] ids, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] string[] attributes, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] string[] attributeValues)
         {
             // Note: MarshalAs decorator is needed when return type is void, otherwise will cause a VBA error on Automation type not supported when passing array
-            var guidList = new List<Guid>();
-            foreach (var id in ids)
-            {
-                guidList.Add(new Guid(id));
-            }
             // Convert positional arrays to Enumerable
             var valueList = new List<(string, object)>();
             for (int i = 0; i < attributes.Length; i++)
             {
                 valueList.Add((attributes[i], attributeValues[i]));
             }
-            Client.WritePropertyMultiple(guidList, valueList);
+            Client.WritePropertyMultiple(ids.Select(id => (ObjectId)id), valueList);
         }
 
         //SendCommand ---------------------------------------------------------------------------------------------------------------
@@ -680,7 +671,7 @@ namespace JohnsonControls.Metasys.ComServices
             SpaceTypeEnum? spaceType = null;
             if (type != null)
             {
-                // Parse type string to SpaceTypeEnum 
+                // Parse type string to SpaceTypeEnum
                 spaceType = (SpaceTypeEnum)Enum.Parse(typeof(SpaceTypeEnum), type);
             }
             // Note: need a generic object as return type in order to map correctly to VBA type array

--- a/MetasysServicesExampleApp/FeaturesDemo/GeneralDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/GeneralDemo.cs
@@ -3,6 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+// Disable warnings on obsolete methods since we still want to test them
+#pragma  warning disable CS0618
+
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
     public class GeneralDemo
@@ -94,7 +97,7 @@ namespace MetasysServicesExampleApp.FeaturesDemo
                 Console.Write("\nEnter one new value for this attribute (this will be applied to both objects): ");
                 object change = Console.ReadLine();
 
-                // Get original values, this code will throw an exception if the 
+                // Get original values, this code will throw an exception if the
                 Variant result1Attr3 = client.ReadProperty(id1, attribute3);
                 Variant result2Attr3 = client.ReadProperty(id2, attribute3);
                 Console.WriteLine($"{result1Attr3.Id} {result1Attr3.Attribute} original value: {result1Attr3.StringValue}");

--- a/MetasysServicesExampleApp/FeaturesDemo/GeneralDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/GeneralDemo.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-// Disable warnings on obsolete methods since we still want to test them
-#pragma  warning disable CS0618
 
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
@@ -34,13 +32,13 @@ namespace MetasysServicesExampleApp.FeaturesDemo
                 Console.WriteLine("\n\nGetObjectIdentifier...");
 
                 // These variables are needed to run the other sections
-                Guid id1 = client.GetObjectIdentifier(object1);
+                var id1 = client.GetObjectIdentifier(object1);
                 Console.WriteLine($"{object1} id: {id1}");
 
-                Guid id2 = client.GetObjectIdentifier(object2);
+                var id2 = client.GetObjectIdentifier(object2);
                 Console.WriteLine($"{object2} id: {id2}");
 
-                List<Guid> ids = new List<Guid>() { id1, id2 };
+                List<ObjectId> ids = [id1, id2];
                 #endregion
 
                 #region ReadProperty

--- a/MetasysServicesExampleApp/FeaturesDemo/GetObjectIdentifierDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/GetObjectIdentifierDemo.cs
@@ -1,8 +1,6 @@
 ﻿using JohnsonControls.Metasys.BasicServices;
 using System;
 
-// Disable warnings on obsolete methods since we still want to use them (for now)
- #pragma  warning disable CS0618
 
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
@@ -25,7 +23,7 @@ namespace MetasysServicesExampleApp.FeaturesDemo
                 string object1 = Console.ReadLine();
                 Console.WriteLine("\n\nGetObjectIdentifier...");
                 // These variables are needed to run the other sections
-                Guid id1 = client.GetObjectIdentifier(object1);
+                var id1 = client.GetObjectIdentifier(object1);
                 Console.WriteLine($"{object1} id: {id1}");
             }
             catch (Exception exception)

--- a/MetasysServicesExampleApp/FeaturesDemo/GetObjectIdentifierDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/GetObjectIdentifierDemo.cs
@@ -1,6 +1,9 @@
 ﻿using JohnsonControls.Metasys.BasicServices;
 using System;
 
+// Disable warnings on obsolete methods since we still want to use them (for now)
+ #pragma  warning disable CS0618
+
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
     public class GetObjectIdentifierDemo

--- a/MetasysServicesExampleApp/FeaturesDemo/JsonOutputDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/JsonOutputDemo.cs
@@ -6,6 +6,9 @@ using System.Globalization;
 using System.Linq;
 using MetasysAttribute = JohnsonControls.Metasys.BasicServices.MetasysAttribute;
 
+// Disable warnings on obsolete methods since we still want to use them (for now)
+ #pragma  warning disable CS0618
+
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
     public class JsonOutputDemo

--- a/MetasysServicesExampleApp/FeaturesDemo/JsonOutputDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/JsonOutputDemo.cs
@@ -6,1147 +6,1146 @@ using System.Globalization;
 using System.Linq;
 using MetasysAttribute = JohnsonControls.Metasys.BasicServices.MetasysAttribute;
 
-// Disable warnings on obsolete methods since we still want to use them (for now)
- #pragma  warning disable CS0618
+
 
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
-    public class JsonOutputDemo
+  public class JsonOutputDemo
+  {
+    private readonly MetasysClient client;
+    private readonly LogInitializer log;
+
+    public JsonOutputDemo(MetasysClient client)
     {
-        private readonly MetasysClient client;
-        private readonly LogInitializer log;
+      this.client = client;
+      log = new LogInitializer(typeof(JsonOutputDemo));
+    }
 
-        public JsonOutputDemo(MetasysClient client)
-        {
-            this.client = client;
-            log = new LogInitializer(typeof(JsonOutputDemo));
-        }
+    #region CREATING A CLIENT
 
-        #region CREATING A CLIENT
+    private void CreateClientSignature1()
+    {
+      /* SNIPPET 1: START */
+      var client = new MetasysClient("hostname");
+      /* SNIPPET 1: END */
 
-        private void CreateClientSignature1()
-        {
-            /* SNIPPET 1: START */
-            var client = new MetasysClient("hostname");
-            /* SNIPPET 1: END */
+    }
 
-        }
+    private void CreateClientSignature2()
+    {
+      /* SNIPPET 2: START */
+      CultureInfo culture = new CultureInfo("it-IT");
+      var client = new MetasysClient("hostname", true, ApiVersion.v2, culture);
+      /* SNIPPET 2: END */
+    }
 
-        private void CreateClientSignature2()
-        {
-            /* SNIPPET 2: START */
-            CultureInfo culture = new CultureInfo("it-IT");
-            var client = new MetasysClient("hostname", true, ApiVersion.v2, culture);
-            /* SNIPPET 2: END */
-        }
+    private void CreateClientSignature3()
+    {
+      /* SNIPPET 3: START */
+      var client = new MetasysClient("hostname", logClientErrors: false);
+      /* SNIPPET 3: END */
+    }
 
-        private void CreateClientSignature3()
-        {
-            /* SNIPPET 3: START */
-            var client = new MetasysClient("hostname", logClientErrors: false);
-            /* SNIPPET 3: END */
-        }
+    private void LogError()
+    {
+      /* SNIPPET 4: START */
+      // Initialize Logger with your context Class
+      var log = new LogInitializer(typeof(Program));
+      try
+      {
+        // Your Try logic here...
+      }
+      catch (Exception ex)
+      {
+        log.Logger.Error(string.Format("An error occured - {0}", ex.Message));
+      }
+      /* SNIPPET 4: END */
+    }
 
-        private void LogError()
-        {
-            /* SNIPPET 4: START */
-            // Initialize Logger with your context Class
-            var log = new LogInitializer(typeof(Program));
-            try
-            {
-                // Your Try logic here...
-            }
-            catch (Exception ex)
-            {
-                log.Logger.Error(string.Format("An error occured - {0}", ex.Message));
-            }
-            /* SNIPPET 4: END */
-        }
+    private void ChangeApiVersion()
+    {
+      /* SNIPPET 5: START */
+      // Changing Api version after creating a client
+      var client = new MetasysClient("hostname", version: ApiVersion.v3);
+      client.Version = ApiVersion.v2;
+      /* SNIPPET 5: END */
+    }
 
-        private void ChangeApiVersion()
-        {
-            /* SNIPPET 5: START */
-            // Changing Api version after creating a client
-            var client = new MetasysClient("hostname", version: ApiVersion.v3);
-            client.Version = ApiVersion.v2;
-            /* SNIPPET 5: END */
-        }
+    private void ChangeHostname()
+    {
+      /* SNIPPET 6: START */
+      // Changing Metasys Server after creating a client
+      var client = new MetasysClient("hostname");
+      client.Hostname = "WIN2016-VM2";
+      /* SNIPPET 6: END */
+    }
 
-        private void ChangeHostname()
-        {
-            /* SNIPPET 6: START */
-            // Changing Metasys Server after creating a client
-            var client = new MetasysClient("hostname");
-            client.Hostname = "WIN2016-VM2";
-            /* SNIPPET 6: END */
-        }
+    #endregion
 
-        #endregion
+    #region LOGIN AND ACCESS TOKENS
+    private void TryLogin_Refresh()
+    {
 
-        #region LOGIN AND ACCESS TOKENS
-        private void TryLogin_Refresh()
-        {
+      /* SNIPPET 1: START */
+      // Automatically refresh token using plain credentials
+      client.TryLogin("username", "password");
+      // Do not automatically refresh token using plain credentials
+      client.TryLogin("username", "password", false);
+      /* SNIPPET 1: END */
 
-            /* SNIPPET 1: START */
-            // Automatically refresh token using plain credentials
-            client.TryLogin("username", "password");
-            // Do not automatically refresh token using plain credentials
-            client.TryLogin("username", "password", false);
-            /* SNIPPET 1: END */
+      /* SNIPPET 2: START */
+      // Read target from Credential Manager and automatically refresh token
+      client.TryLogin("metasys-energy-app");
+      // Read target from Credential Manager and do not refresh token
+      client.TryLogin("metasys-energy-app", false);
+      /* SNIPPET 2: END */
 
-            /* SNIPPET 2: START */
-            // Read target from Credential Manager and automatically refresh token
-            client.TryLogin("metasys-energy-app");
-            // Read target from Credential Manager and do not refresh token
-            client.TryLogin("metasys-energy-app", false);
-            /* SNIPPET 2: END */
+      /* SNIPPET 3: START */
+      AccessToken accessToken = client.TryLogin("metasys-energy-app");
+      Console.WriteLine(accessToken);
+      /*
+          {
+            "Issuer": "metasysserver",
+            "IssuedTo": "metasysapiuser",
+            "Token": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkJzR0lWelVZcjN0MkI0RGRtT1ljMTdBLVZJOCIsImtpZCI6IkJzR0lWelVZcjN0MkI0RGRtT1ljMTdBLVZJOCJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojk1MDYvQVBJLkF1dGhlbnRpY2F0aW9uU2VydmljZSIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTUwNi9BUEkuQXV0aGVudGljYXRpb25TZXJ2aWNlL3Jlc291cmNlcyIsImV4cCI6MTU4OTI5MzEzMCwibmJmIjoxNTg5MjkxMzMwLCJjbGllbnRfaWQiOiJtZXRhc3lzX3VpIiwic2NvcGUiOlsibWV0YXN5c19hcGkiLCJvZmZsaW5lX2FjY2VzcyIsIm9wZW5pZCJdLCJzdWIiOiI4ZGE4YjE4Yy1lMTk1LTRlMmMtOGU2Zi0zNTE2Zjc0ZWFhNGIiLCJhdXRoX3RpbWUiOjE1ODkyOTEzMzAsImlkcCI6Imlkc3J2IiwiVXNlcklkIjoiMSIsIlVzZXJOYW1lIjoibWV0YXN5c3N5c2FnZW50IiwiSXNBZG1pbiI6IlRydWUiLCJJc1Bhc3N3b3JkQ2hhbmdlUmVxdWlyZWQiOiJGYWxzZSIsIklzVGVybXNBbmRDb25kaXRpb25zUmVxdWlyZWQiOiJGYWxzZSIsIkxpY2Vuc2VJbmZvIjoie1wiSXNMaWNlbnNlZFwiOnRydWUsXCJMaWNlbnNlVHlwZVwiOlwiZ3JhY2VcIn0iLCJDdWx0dXJlIjoiZW4tVVMiLCJhbXIiOlsicGFzc3dvcmQiXX0.egzw1bs1831pEBWWXbBOYWGU5wFsI3sEnL7RgCIHHbHmcxtpPPqLq54znpoUoLFrMUeymZj5rkrt_mF-CNIpCE3halZNAH-CR1U46LTZi5CMaDfYlP-wHxikAGV5GwFjlHjGNOUaFtd7n4yC5sH08pHQfXXD5gKDm_FVMfUJXAo-E8gmrkU0wMn5U2FRyQyj7Yhq6jaj7MPTF__Xz46sG3WtDr45WK2NmuwiLDv408URZ5fJxlMngRpjSIONHVAIwna_H0AguHiIELkvuRVYcRqIH5kb1YdFt-3fsnTV9xwpozZZ44dh-4I7x466I-UGlLHAnScWILUbPcpRNWm0Uw",
+            "Expires": "2020-05-12T14:18:51Z"
+          }
+       */
+      /* SNIPPET 3: END */
 
-            /* SNIPPET 3: START */
-            AccessToken accessToken = client.TryLogin("metasys-energy-app");
-            Console.WriteLine(accessToken);
-            /*        
-                {
-                  "Issuer": "metasysserver",
-                  "IssuedTo": "metasysapiuser",
-                  "Token": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkJzR0lWelVZcjN0MkI0RGRtT1ljMTdBLVZJOCIsImtpZCI6IkJzR0lWelVZcjN0MkI0RGRtT1ljMTdBLVZJOCJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojk1MDYvQVBJLkF1dGhlbnRpY2F0aW9uU2VydmljZSIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTUwNi9BUEkuQXV0aGVudGljYXRpb25TZXJ2aWNlL3Jlc291cmNlcyIsImV4cCI6MTU4OTI5MzEzMCwibmJmIjoxNTg5MjkxMzMwLCJjbGllbnRfaWQiOiJtZXRhc3lzX3VpIiwic2NvcGUiOlsibWV0YXN5c19hcGkiLCJvZmZsaW5lX2FjY2VzcyIsIm9wZW5pZCJdLCJzdWIiOiI4ZGE4YjE4Yy1lMTk1LTRlMmMtOGU2Zi0zNTE2Zjc0ZWFhNGIiLCJhdXRoX3RpbWUiOjE1ODkyOTEzMzAsImlkcCI6Imlkc3J2IiwiVXNlcklkIjoiMSIsIlVzZXJOYW1lIjoibWV0YXN5c3N5c2FnZW50IiwiSXNBZG1pbiI6IlRydWUiLCJJc1Bhc3N3b3JkQ2hhbmdlUmVxdWlyZWQiOiJGYWxzZSIsIklzVGVybXNBbmRDb25kaXRpb25zUmVxdWlyZWQiOiJGYWxzZSIsIkxpY2Vuc2VJbmZvIjoie1wiSXNMaWNlbnNlZFwiOnRydWUsXCJMaWNlbnNlVHlwZVwiOlwiZ3JhY2VcIn0iLCJDdWx0dXJlIjoiZW4tVVMiLCJhbXIiOlsicGFzc3dvcmQiXX0.egzw1bs1831pEBWWXbBOYWGU5wFsI3sEnL7RgCIHHbHmcxtpPPqLq54znpoUoLFrMUeymZj5rkrt_mF-CNIpCE3halZNAH-CR1U46LTZi5CMaDfYlP-wHxikAGV5GwFjlHjGNOUaFtd7n4yC5sH08pHQfXXD5gKDm_FVMfUJXAo-E8gmrkU0wMn5U2FRyQyj7Yhq6jaj7MPTF__Xz46sG3WtDr45WK2NmuwiLDv408URZ5fJxlMngRpjSIONHVAIwna_H0AguHiIELkvuRVYcRqIH5kb1YdFt-3fsnTV9xwpozZZ44dh-4I7x466I-UGlLHAnScWILUbPcpRNWm0Uw",
-                  "Expires": "2020-05-12T14:18:51Z"
-                }
-             */
-            /* SNIPPET 3: END */
+      /* SNIPPET 4: START */
+      client.Refresh();
+      /* SNIPPET 4: END */
+    }
+    #endregion
 
-            /* SNIPPET 4: START */
-            client.Refresh();
-            /* SNIPPET 4: END */
-        }
-        #endregion
+    #region GET AN OBJECT ID
+    private void GetObjectIdentifier()
+    {
+      /* SNIPPET 1: START */
+      var objectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
+      Console.WriteLine(objectId);
+      /*
+      d5d96cd3-db4a-52e0-affd-8bc3393c30ec
+       */
+      /* SNIPPET 1: END */
+    }
+    #endregion
 
-        #region GET AN OBJECT ID
-        private void GetObjectIdentifier()
-        {
-            /* SNIPPET 1: START */
-            Guid objectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
-            Console.WriteLine(objectId);
-            /*        
-            d5d96cd3-db4a-52e0-affd-8bc3393c30ec
-             */
-            /* SNIPPET 1: END */
-        }
-        #endregion
-
-        #region GET A PROPERTY
-        private void ReadProperty(Guid objectId)
-        {
-            /* SNIPPET 1: START */
-            Variant property = client.ReadProperty(objectId, "presentValue");
-            Console.WriteLine(property);
-            /*        
-               {
-                  "StringValue": "72",
-                  "StringValueEnumerationKey": null,
-                  "NumericValue": 72.0,
-                  "BooleanValue": true,
+    #region GET A PROPERTY
+    private void ReadProperty(ObjectId objectId)
+    {
+      /* SNIPPET 1: START */
+      Variant property = client.ReadProperty(objectId, "presentValue");
+      Console.WriteLine(property);
+      /*
+         {
+            "StringValue": "72",
+            "StringValueEnumerationKey": null,
+            "NumericValue": 72.0,
+            "BooleanValue": true,
+            "ArrayValue": null,
+            "Attribute": "presentValue",
+            "Id": "f1469e25-c46c-5009-b92e-d82603e742a4",
+            "Reliability": "Reliable",
+            "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
+            "Priority": "0 (No Priority)",
+            "PriorityEnumerationKey": "writePriorityEnumSet.priorityNone",
+            "IsReliable": true
+          }
+       */
+      /* SNIPPET 1: END */
+    }
+    private void ReadPropertyMultiple(ObjectId id1, ObjectId id2)
+    {
+      /* SNIPPET 2: START */
+      List<ObjectId> ids = [id1, id2];
+      List<string> attributes = new List<string> { "name", "description", "presentValue" };
+      IEnumerable<VariantMultiple> results = client.ReadPropertyMultiple(ids, attributes);
+      VariantMultiple multiple1 = results.FindById(id1);
+      Console.WriteLine(multiple1);
+      /*
+          {
+              "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
+              "Variants": [
+              {
+                  "StringValue": "ZN-T",
+                  "StringValueEnumerationKey": "ZN-T",
+                  "NumericValue": 0.0,
+                  "BooleanValue": false,
                   "ArrayValue": null,
-                  "Attribute": "presentValue",
-                  "Id": "f1469e25-c46c-5009-b92e-d82603e742a4",
+                  "Attribute": "name",
+                  "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
                   "Reliability": "Reliable",
                   "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
-                  "Priority": "0 (No Priority)",
-                  "PriorityEnumerationKey": "writePriorityEnumSet.priorityNone",
+                  "Priority": null,
+                  "PriorityEnumerationKey": null,
                   "IsReliable": true
-                }
-             */
-            /* SNIPPET 1: END */
-        }
-        private void ReadPropertyMultiple(Guid id1, Guid id2)
-        {
-            /* SNIPPET 2: START */
-            List<Guid> ids = new List<Guid> { id1, id2 };
-            List<string> attributes = new List<string> { "name", "description", "presentValue" };
-            IEnumerable<VariantMultiple> results = client.ReadPropertyMultiple(ids, attributes);
-            VariantMultiple multiple1 = results.FindById(id1);
-            Console.WriteLine(multiple1);
-            /*
-                {
-                    "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
-                    "Variants": [
-                    {
-                        "StringValue": "ZN-T",
-                        "StringValueEnumerationKey": "ZN-T",
-                        "NumericValue": 0.0,
-                        "BooleanValue": false,
-                        "ArrayValue": null,
-                        "Attribute": "name",
-                        "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
-                        "Reliability": "Reliable",
-                        "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
-                        "Priority": null,
-                        "PriorityEnumerationKey": null,
-                        "IsReliable": true
-                    },
-                    {
-                        "StringValue": "Zone Temperature",
-                        "StringValueEnumerationKey": "Zone Temperature",
-                        "NumericValue": 0.0,
-                        "BooleanValue": false,
-                        "ArrayValue": null,
-                        "Attribute": "description",
-                        "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
-                        "Reliability": "Reliable",
-                        "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
-                        "Priority": null,
-                        "PriorityEnumerationKey": null,
-                        "IsReliable": true
-                    }
-                    ]
-                }
-            */
-            Variant multiple1Description = multiple1.FindAttributeByName("description");
-            /* SNIPPET 2: END */
-        }
-        #endregion
-
-        #region WRITE A PROPERTY
-        private void WriteProperty()
-        {
-            /* SNIPPET 1: START */
-            Guid id = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
-            client.WriteProperty(id, "description", "This is an AV.");
-            /* SNIPPET 1: END */
-        }
-        private void WritePropertyMultiple(Guid id1, Guid id2)
-        {
-            /* SNIPPET 2: START */
-            List<Guid> ids = new List<Guid> { id1, id2 };
-            // Write to many attributes values using a list of tuples
-            List<(string, object)> attributesList = new List<(string, object)> { ("description", "This is an AV.") };
-            client.WritePropertyMultiple(ids, attributesList);
-            // Write to many attributes values using a dictionary of attribute/value pairs
-            Dictionary<string, object> attributesDictionary = new Dictionary<string, object> { { "description", "This is an AV." } };
-            client.WritePropertyMultiple(ids, attributesDictionary);
-            /* SNIPPET 2: END */
-        }
-        #endregion
-
-        #region GET AND SEND COMMANDS
-        private void GetCommands(Guid objectId)
-        {
-            /* SNIPPET 1: START */
-            List<Command> commands = client.GetCommands(objectId).ToList();
-            Command command = commands.FindById("adjust");
-            Console.WriteLine(command);
-            /*
-                {
-                  "Title": "Adjust",
-                  "TitleEnumerationKey": "commandIdEnumSet.adjustCommand",
-                  "CommandId": "Adjust",
-                  "Items": [
-                    {
-                      "Title": "Value",
-                      "Type": "number",
-                      "EnumerationValues": null,
-                      "Minimum": null,
-                      "Maximum": null
-                    }
-                  ]
-                }
-            */
-            /* SNIPPET 1: END */
-        }
-        private void SendCommands(Guid objectId, List<Command> commands)
-        {
-            /* SNIPPET 2: START */
-            Command adjust = commands.FindById("adjust");
-            Command operatorOverride = commands.FindById("operatorOverride");
-            Command release = commands.FindById("release");
-            Console.WriteLine(release);
-            /*                        
+              },
               {
-                  "Title": "Release",
-                  "TitleEnumerationKey": "commandIdEnumSet.releaseCommand",
-                  "CommandId": "Release",
-                  "Items": [
-                    {
-                      "Title": "oneOf",
-                      "Type": "enum",
-                      "EnumerationValues": [
-                        {
-                          "Title": "Present Value",
-                          "TitleEnumerationKey": "attributeEnumSet.presentValue"
-                        }
-                      ],
-                      "Minimum": 1.0,
-                      "Maximum": 1.0
-                    },
-                    {
-                      "Title": "oneOf",
-                      "Type": "enum",
-                      "EnumerationValues": [
-                        {
-                          "Title": "0 (No Priority)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityNone"
-                        },
-                        {
-                          "Title": "1 (Manual Life Safety)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityManualEmergency"
-                        },
-                        {
-                          "Title": "2 (Auto Life Safety)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityFireApplications"
-                        },
-                        {
-                          "Title": "3 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority3"
-                        },
-                        {
-                          "Title": "4 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority4"
-                        },
-                        {
-                          "Title": "5 (Critical Equipment)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityCriticalEquipment"
-                        },
-                        {
-                          "Title": "6 (Minimum On Off)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityMinimumOnOff"
-                        },
-                        {
-                          "Title": "7 (Heavy Equip Delay)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityHeavyEquipDelay"
-                        },
-                        {
-                          "Title": "8 (Operator Override)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityOperatorOverride"
-                        },
-                        {
-                          "Title": "9 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority9"
-                        },
-                        {
-                          "Title": "10 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority10"
-                        },
-                        {
-                          "Title": "11 (Demand Limiting)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityDemandLimiting"
-                        },
-                        {
-                          "Title": "12 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority12"
-                        },
-                        {
-                          "Title": "13 (Load Rolling)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityLoadRolling"
-                        },
-                        {
-                          "Title": "14 (Application)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priority14"
-                        },
-                        {
-                          "Title": "15 (Scheduling)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.prioritySchedulingOst"
-                        },
-                        {
-                          "Title": "16 (Default)",
-                          "TitleEnumerationKey": "writePriorityEnumSet.priorityDefault"
-                        }
-                      ],
-                      "Minimum": 1.0,
-                      "Maximum": 1.0
-                    }
-                  ]
-                }
-            */
-            var list1 = new List<object> { 70 };
-            client.SendCommand(objectId, adjust.CommandId, list1);
-            var list2 = new List<object> { 75 };
-            client.SendCommand(objectId, operatorOverride.CommandId, list2);
-            var list3 = new List<object> { "attributeEnumSet.presentValue", "writePriorityEnumSet.priorityNone" };
-            client.SendCommand(objectId, release.CommandId, list3);
-            /* SNIPPET 2: END */
-        }
-        #endregion
-
-        #region GET NETWORK DEVICES AND OBJECT CHILDREN
-        private void GetNetworkDeviceTypes_GetNetworkDevices()
-        {
-            /* SNIPPET 1: START */
-            List<MetasysObjectType> types = client.GetNetworkDeviceTypes().ToList();
-            Console.WriteLine(types[0]);
-            /*
-            {
-              "Description": "NAE55-NIE59",
-              "DescriptionEnumerationKey": "objectTypeEnumSet.n50Class",
-              "Id": 185
-            }
-            */
-            int type1 = types[0].Id;
-            List<MetasysObject> devices = client.GetNetworkDevices(type1.ToString()).ToList();
-            MetasysObject device = devices.LastOrDefault();
-            Console.WriteLine(device);
-            /*
-                {
-                  "ItemReference": "Win2016-VM2:vNAE2343996",
-                  "Id": "142558f8-c4c7-5f89-be97-d806adb72053",
-                  "Name": "vNAE2343996",
-                  "Description": "",
-                  "Type": null,
-                  "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/185",
-                  "Category": null,
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-            */
-
-            List<MetasysObject> devices2 = client.GetNetworkDevices(NetworkDeviceTypeEnum.SNC).ToList();
-            MetasysObject device2 = devices2.LastOrDefault();
-            Console.WriteLine(device2);
-            /*                        
-                {
-                  "ItemReference": "WIN-21DJ9JV9QH6:EECMI-SNC-KNX",
-                  "Id": "69b3c2a5-1090-5418-afd9-5efc7186e42f",
-                  "Name": "EECMI-SNC-KNX",
-                  "Description": "",
-                  "Type": null,
-                  "TypeUrl": "https://win-21dj9jv9qh6/api/v3/enumSets/508/members/448",
-                  "ObjectType": null,
-                  "Category": null,
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-            */
-
-
-            /* SNIPPET 1: END */
-        }
-
-        private void GetObjects()
-        {
-            /* SNIPPET 2: START */
-            Guid parentId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB");
-            // Get direct children (1 level)
-            List<MetasysObject> directChildren = client.GetObjects(parentId).ToList();
-            MetasysObject lastChild = directChildren.LastOrDefault();
-            Console.WriteLine(lastChild);
-            /*
-                {
-                  "ItemReference": "Win2016-VM2:vNAE2343996/Field Bus MSTP1.VAV-08.ZN-T",
+                  "StringValue": "Zone Temperature",
+                  "StringValueEnumerationKey": "Zone Temperature",
+                  "NumericValue": 0.0,
+                  "BooleanValue": false,
+                  "ArrayValue": null,
+                  "Attribute": "description",
                   "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
-                  "Name": "ZN-T",
-                  "Description": null,
-                  "Type": null,
-                  "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/601",
-                  "Category": null,
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-               */
-            // Get direct children (1 level) with internal objects
-            directChildren = client.GetObjects(parentId, includeInternalObjects: true).ToList();
-            // Get descendant for 2 levels (it could take long time, depending on the number of objects)
-            List<MetasysObject> level2Descendants = client.GetObjects(parentId, 2).ToList();
-            MetasysObject level1Parent = level2Descendants.FindByName("Time");
-            Console.WriteLine(level1Parent);
-            /*                        
-              {
-                "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time",
-                "Id": "22bb952e-7557-5de9-b7e5-dce39e21addd",
-                "Name": "Time",
-                "Description": null,
-                "Type": null,
-                "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/176",
-                "Category": null,
-                "Children": [
-                {
-                    "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Day",
-                    "Id": "5886a93f-9260-553c-995e-6a65374de85d",
-                    "Name": "Day",
-                    "Description": null,
-                    "Type": null,
-                    "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
-                    "Category": null,
-                    "Children": [],
-                    "ChildrenCount": 0
-                },
-                {
-                    "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Hour",
-                    "Id": "6a50d3af-d0a2-537c-a2f7-9c1b5f271cc5",
-                    "Name": "Hour",
-                    "Description": null,
-                    "Type": null,
-                    "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
-                    "Category": null,
-                    "Children": [],
-                    "ChildrenCount": 0
-                },
-                {
-                    "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Minute",
-                    "Id": "19a53f38-2fd7-5ac3-a12c-f3b9704ac194",
-                    "Name": "Minute",
-                    "Description": null,
-                    "Type": null,
-                    "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
-                    "Category": null,
-                    "Children": [],
-                    "ChildrenCount": 0
-                },
-                {
-                    "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Year",
-                    "Id": "74dfc214-22c1-57a7-ace5-606636d0049c",
-                    "Name": "Year",
-                    "Description": null,
-                    "Type": null,
-                    "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
-                    "Category": null,
-                    "Children": [],
-                    "ChildrenCount": 0
-                }
-                ],
-                "ChildrenCount": 4
-            }
-               */
-            /* SNIPPET 2: END */
-        }
-        #endregion
-
-        #region LOCALIZATION OF METASYS ENUMERATIONS
-        private void Localize()
-        {
-            /* SNIPPET 1: START */
-            client.Culture = new CultureInfo("en-US");
-            /* SNIPPET 1: END */
-
-            /* SNIPPET 2: START */
-            // Access from the client object (uses client.Culture as input)
-            string translated = client.Localize("reliabilityEnumSet.reliable");
-            Console.WriteLine(translated);
-            /*
-                Reliable
-              */
-            // Access without instantiating a client
-            translated = ResourceManager.Localize("reliabilityEnumSet.reliable",
-                new CultureInfo("it-IT"));
-            Console.WriteLine(translated);
-            /*
-                Affidabile
-              */
-            /* SNIPPET 2: END */
-        }
-        #endregion
-
-        #region SPACES AND EQUIPMENT
-        private void GetSpaces()
-        {
-            /* SNIPPET 1: START */
-            // Retrieves the list of Buildings using SpaceTypeEnum helper
-            List<MetasysObject> buildings = client.GetSpaces(SpaceTypeEnum.Building).ToList();
-            MetasysObject building = buildings.LastOrDefault();
-            Console.WriteLine(building);
-            /*                        
-                {
-                  "ItemReference": "Win2016-VM2:Win2016-VM2/JCI.Building 1",
-                  "Id": "164aaba2-0fb3-5b5d-bfe9-49cf6b797c93",
-                  "Name": "North America (BACnet)",
-                  "Description": null,
-                  "Type": 2,
-                  "TypeUrl": "https://win2016-vm2/api/v2/enumSets/1766/members/1",
-                  "Category": "Building",
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-             */
-            // Retrieves all the spaces in a flat hierarchy
-            List<MetasysObject> spaces = client.GetSpaces().ToList();
-            MetasysObject firstSpace = spaces.FirstOrDefault();
-            Console.WriteLine(firstSpace);
-            /*                        
-                {
-                  "ItemReference": "Win2016-VM2:Win2016-VM2/JCI.Building 1.Floor 1.Milwaukee.507 E Michigan Street Campus",
-                  "Id": "896ba096-db3c-5038-8505-636785906cca",
-                  "Name": "507 E Michigan Street Campus",
-                  "Description": null,
-                  "Type": 2,
-                  "TypeUrl": "https://win2016-vm2/api/v2/enumSets/1766/members/3",
-                  "Category": "Room",
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-             */
-            /* SNIPPET 1: END */
-        }
-
-        private void GetSpaceTypes()
-        {
-            /* SNIPPET 2: START */
-            IEnumerable<MetasysObjectType> spaceTypes = client.GetSpaceTypes();
-            foreach (var type in spaceTypes)
-            {
-                Console.WriteLine(type);
-            }
-            /*
-                {
-                  "Description": "Building",
-                  "DescriptionEnumerationKey": "Building",
-                  "Id": 1
-                }
-                {
-                  "Description": "Floor",
-                  "DescriptionEnumerationKey": "Floor",
-                  "Id": 2
-                }
-                {
-                  "Description": "Generic",
-                  "DescriptionEnumerationKey": "Generic",
-                  "Id": 0
-                }
-                {
-                  "Description": "Room",
-                  "DescriptionEnumerationKey": "Room",
-                  "Id": 3
-                }
-             */
-            /* SNIPPET 2: END */
-        }
-
-        private void GetEquipment()
-        {
-            /* SNIPPET 3: START */
-            List<MetasysObject> equipment = client.GetEquipment().ToList();
-            MetasysObject sampleEquipment = equipment.FirstOrDefault();
-            Console.WriteLine(sampleEquipment);
-            /*                        
-                 {
-                  "ItemReference": "Win2016-VM2:Win2016-VM2/equipment.vNAE2343947.Field Bus MSTP1.AHU-07",
-                  "Id": "6c6e18b8-015f-572a-814c-1e5d66142850",
-                  "Name": "AHU-07",
-                  "Description": null,
-                  "Type": 3,
-                  "TypeUrl": null,
-                  "Category": null,
-                  "Children": [],
-                  "ChildrenCount": 0
-                }
-             */
-            /* SNIPPET 3: END */
-
-        }
-
-        private void GetSpaceEquipment_GetSpaceChildren(Guid spaceId)
-        {
-            /* SNIPPET 4: START */
-            IEnumerable<MetasysObject> spaceEquipment = client.GetSpaceEquipment(spaceId);
-
-            IEnumerable<MetasysObject> spaceChildren = client.GetSpaceChildren(spaceId);
-            MetasysObject sampleSpaceEquipment = spaceEquipment.FirstOrDefault();
-            /* SNIPPET 4: END */
-        }
-
-        private void GetEquipmentPoints(MetasysObject sampleEquipment)
-        {
-            /* SNIPPET 5: START */
-            IEnumerable<MetasysPoint> equipmentPoints = client.GetEquipmentPoints(sampleEquipment.Id);
-            MetasysPoint point = equipmentPoints.FindByShortName("Analog Input-1");
-            string presentValue = point.PresentValue?.StringValue;
-            Console.WriteLine(point);
-            /*
-                {
-                  "EquipmentName": "AHU-07",
-                  "ShortName": "CLG-O",
-                  "Label": "Cooling Output",
-                  "Category": "",
-                  "IsDisplayData": true,
-                  "ObjectId": "9dd107cf-e8dc-583a-9557-813395ae1971",
-                  "AttributeUrl": "https://win2016-vm2/api/v2/enumSets/509/members/85",
-                  "ObjectUrl": "https://win2016-vm2/api/v2/objects/9dd107cf-e8dc-583a-9557-813395ae1971",
-                  "PresentValue": {
-                    "StringValue": "0",
-                    "StringValueEnumerationKey": null,
-                    "NumericValue": 0.0,
-                    "BooleanValue": false,
-                    "ArrayValue": null,
-                    "Attribute": "presentValue",
-                    "Id": "9dd107cf-e8dc-583a-9557-813395ae1971",
-                    "Reliability": "Reliable",
-                    "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
-                    "Priority": "0 (No Priority)",
-                    "PriorityEnumerationKey": "writePriorityEnumSet.priorityNone",
-                    "IsReliable": true
-                  }
-                }
-             */
-            /* SNIPPET 5: END */
-        }
-        #endregion
-
-        #region ALARMS
-        private void GetAlarms()
-        {
-            /* SNIPPET 1: START */
-            AlarmFilter alarmFilter = new AlarmFilter
-            {
-                StartTime = new DateTime(2020, 6, 1),
-                EndTime = new DateTime(2020, 6, 18),
-                ExcludeAcknowledged = true
-            };
-            PagedResult<Alarm> alarmsPager = client.Alarms.Get(alarmFilter);
-            // Prints the number of records fetched and paging information
-            Console.WriteLine("Total:" + alarmsPager.Total);
-            Console.WriteLine("Current page:" + alarmsPager.CurrentPage);
-            Console.WriteLine("Page size:" + alarmsPager.PageSize);
-            Console.WriteLine("Pages:" + alarmsPager.PageCount);
-            /* Console Output: Start
-                Total:4611
-                Current page:1
-                Page size:100
-                Pages:47
-            Console Output: End */
-            Alarm alarm = alarmsPager.Items.ElementAt(0);
-            Console.WriteLine(alarm);
-            /* Console Output: Start
-            {
-              "Self": "https://win-21dj9jv9qh6/api/v3/alarms/e03d81f9-69de-48e8-92d7-81167df19f6c",
-              "Id": "e03d81f9-69de-48e8-92d7-81167df19f6c",
-              "ItemReference": "WIN-21DJ9JV9QH6:EECMI-NCE25-3",
-              "Name": "EECMI-NCE25-3",
-              "Message": "WIN-21DJ9JV9QH6:EECMI-NCE25-3 is offline",
-              "IsAckRequired": true,
-              "TypeUrl": null,
-              "Type": "alarmValueEnumSet.avOffline",
-              "Priority": 106,
-              "TriggerValue": {
-                "Value": "",
-                "UnitsUrl": null,
-                "Units": "unitEnumSet.noUnits"
-              },
-              "CreationTime": "2020-06-17T11:22:30Z",
-              "IsAcknowledged": false,
-              "IsDiscarded": false,
-              "CategoryUrl": null,
-              "Category": "objectCategoryEnumSet.systemCategory",
-              "ObjectUrl": "https://win-21dj9jv9qh6/api/v3/objects/e03d81f9-69de-48e8-92d7-81167df19f6c",
-              "AnnotationsUrl": "https://win-21dj9jv9qh6/api/v3/alarms/e03d81f9-69de-48e8-92d7-81167df19f6c/annotations"
-            }             
-            Console Output: End */
-            /* SNIPPET 1: END */
-        }
-
-        private void GetSingleAlarm_GetAlarmsForAnObject_GetAlarmsForNetworkDevice(Alarm alarm, Guid objectId, AlarmFilter alarmFilter, MetasysObject device)
-        {
-            /* SNIPPET 2: START */
-            Alarm singleAlarm = client.Alarms.FindById(alarm.Id);
-            PagedResult<Alarm> objectAlarms = client.Alarms.GetForObject(objectId, alarmFilter);
-            PagedResult<Alarm> deviceAlarms = client.Alarms.GetForNetworkDevice(device.Id, alarmFilter);
-            /* SNIPPET 2: END */
-        }
-
-        private void GetAlarmsAnnotation(Alarm alarm)
-        {
-            /* SNIPPET 3: START */
-            IEnumerable<AlarmAnnotation> annotations = client.Alarms.GetAnnotations(alarm.Id);
-            AlarmAnnotation firstAnnotation = annotations.FirstOrDefault();
-            Console.WriteLine(firstAnnotation);
-            /*
-            {
-                "AlarmUrl": "https://win-ervotujej94/api/v2/alarms/f0f64d5c-b70e-8754-836c-1ac99182f4e4",
-                "Text": "Test Annotation 00",
-                "User": "metasyssysagent",
-                "CreationTime": "2020-05-27T06:21:31Z",
-                "Action": "none"
-            } 
-            */
-            /* SNIPPET 3: END */
-        }
-        #endregion
-
-        #region TRENDS
-        private void GetTrendedAttributes_GetSamples()
-        {
-            /* SNIPPET 1: START */
-            Guid trendedObjectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
-            // Get attributes where trend extension is configured
-            List<MetasysAttribute> trendedAttributes = client.Trends.GetTrendedAttributes(trendedObjectId);
-            int attributeId = trendedAttributes[0].Id;
-            TimeFilter timeFilter = new TimeFilter
-            {
-                StartTime = new DateTime(2020, 6, 5),
-                EndTime = new DateTime(2020, 6, 6)
-            };
-            PagedResult<Sample> samplesPager = client.Trends.GetSamples(trendedObjectId, attributeId, timeFilter);
-            // Prints the number of records fetched and paging information
-            Console.WriteLine("Total:" + samplesPager.Total);
-            Console.WriteLine("Current page:" + samplesPager.CurrentPage);
-            Console.WriteLine("Page size:" + samplesPager.PageSize);
-            Console.WriteLine("Pages:" + samplesPager.PageCount);
-            /*
-                Total:145
-                Current page:1
-                Page size:100
-                Pages:2
-             */
-            Sample firstSample = samplesPager.Items.FirstOrDefault();
-            Console.WriteLine(firstSample);
-            /*
-                {
-                  "Value": 82.0,
-                  "Unit": "deg F",
-                  "Timestamp": "2020-05-12T05:00:00Z",
+                  "Reliability": "Reliable",
+                  "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
+                  "Priority": null,
+                  "PriorityEnumerationKey": null,
                   "IsReliable": true
-                }
-              */
-            /* SNIPPET 1: END */
-        }
-        #endregion
-
-        #region AUDITS
-        private void GetAudits()
-        {
-            /* SNIPPET 1: START */
-            AuditFilter auditFilter = new AuditFilter
-            {
-                StartTime = new DateTime(2020, 06, 01),
-                EndTime = new DateTime(2020, 06, 24),
-                OriginApplications = OriginApplicationsEnum.SystemSecurity | OriginApplicationsEnum.AuditTrails,
-                ActionTypes = ActionTypeEnum.Subsystem | ActionTypeEnum.Command
-            };
-            PagedResult<Audit> auditsPager = client.Audits.Get(auditFilter);
-            // Prints the number of records fetched and paging information
-            Console.WriteLine("Total:" + auditsPager.Total);
-            Console.WriteLine("Current page:" + auditsPager.CurrentPage);
-            Console.WriteLine("Page size:" + auditsPager.PageSize);
-            Console.WriteLine("Pages:" + auditsPager.PageCount);
-            /*
-                Total:323
-                Current page:1
-                Page size:100
-                Pages:4
-             */
-            Audit audit = auditsPager.Items.FirstOrDefault();
-            Console.WriteLine(audit);
-            /*
-            {
-              "Id": "8e3b3738-2f5f-494d-bde1-fac15da28c86",
-              "CreationTime": "2020-06-23T16:45:54.697Z",
-              "ActionTypeUrl": null,
-              "ActionType": "auditActionTypeEnumSet.subsystemAuditActionType",
-              "Discarded": false,
-              "StatusUrl": null,
-              "Status": null,
-              "PreData": null,
-              "PostData": "::1",
-              "Parameters": "[]",
-              "ErrorString": null,
-              "User": "testuser",
-              "Signature": null,
-              "ObjectUrl": "https://win-21dj9jv9qh6/api/v3/objects/1949c631-7823-5230-b951-aae3f8c9d64a",
-              "AnnotationsUrl": null,
-              "Legacy": {
-                "FullyQualifiedItemReference": "WIN-21DJ9JV9QH6:WIN-21DJ9JV9QH6",
-                "ItemName": "EECMI-ADS11",
-                "ClassLevel": "auditClassesEnumSet.userActionAuditClass",
-                "OriginApplication": "auditOriginAppEnumSet.systemSecurityAuditOriginApp",
-                "Description": "auditTrailStringsEnumSet.atstrSecurityUserLoginSuccessful"
-              },
-              "Self": "https://win-21dj9jv9qh6/api/v3/audits/8e3b3738-2f5f-494d-bde1-fac15da28c86"
-            }
-             */
-            /* SNIPPET 1: END */
-        }
-
-        private void GetSingleAudit_GetAuditsForAnObject(Audit audit, Guid objectId, AuditFilter auditFilter)
-        {
-            /* SNIPPET 2: START */
-            Audit singleAudit = client.Audits.FindById(audit.Id);
-            PagedResult<Audit> objectAudits = client.Audits.GetForObject(objectId, auditFilter);
-            /* SNIPPET 2: END */
-        }
-
-        private void GetAuditsAnnotation(Audit audit)
-        {
-            /* SNIPPET 3: START */
-            Guid auditId = new Guid("f798591b-e6d6-441f-8f7b-596fc2e6c003");
-            IEnumerable<AuditAnnotation> annotations = client.Audits.GetAnnotations(auditId);
-            AuditAnnotation firstAnnotation = annotations.FirstOrDefault();
-            Console.WriteLine(firstAnnotation);
-            /*
-            {
-                "auditUrl": "https://win-ervotujej94/api/v2/audits/40aff6ec-ecb2-4b65-a504-0ac659756956",
-                "creationTime": "2020-06-05T15:58:40.407Z",
-                "user": "MetasysSysAgent",
-                "text": "TEST AUDIT ANNOTATION 02",
-                "signature": null,
-                "action": "none"
-            } 
-            */
-            /* SNIPPET 3: END */
-        }
-
-        private void DiscardSingleAudit(Audit audit)
-        {
-
-            /* SNIPPET 4: START */
-            string annotationText = "Reason why the audit has been discarded";
-            client.Audits.Discard(audit.Id, annotationText);
-            /* SNIPPET 4: END */
-        }
-
-        private void AddAuditAnnotation(Audit audit)
-        {
-            /* SNIPPET 5: START */
-            string annotationText = "This is the text of the annotation";
-            client.Audits.AddAnnotation(audit.Id, annotationText);
-            /* SNIPPET 5: END */
-        }
-
-        private void AddAuditAnnotationMultiple()
-        {
-            /* SNIPPET 6: START */
-            var requests = new List<BatchRequestParam>();
-            BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("f179a59c-ce36-47e1-afa6-f873b80259ed"), Resource = "THIS IS THE FIRST AUDIT ANNOTATION" };
-            requests.Add(request1);
-            BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("bccc567c-300b-4d38-894c-104cdd6e2836"), Resource = "THIS IS THE SECOND AUDIT ANNOTATION" };
-            requests.Add(request2);
-
-            IEnumerable<Result> results = client.Audits.AddAnnotationMultiple(requests);
-            Result resultItem = results.ElementAt(0);
-            Console.WriteLine(resultItem);
-            /*
-            {
-              "Id": "e0fb025a-d8a2-4258-91ea-c4026c1620d1",
-              "Status": 201,
-              "Annotation": "THIS IS THE FIRST AUDIT ANNOTATION"
-            }            /*
-            */
-            /* SNIPPET 6: END */
-        }
-        private void DiscardAuditMultiple()
-        {
-
-            /* SNIPPET 7: START */
-            var requests = new List<BatchRequestParam>();
-            BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("030d3998-3145-44d9-b378-886e52d373c1"), Resource = "THIS IS THE FIRST DISCARD ANNOTATION" };
-            requests.Add(request1);
-            BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("181a6677-ccbd-4b97-9438-5b331ffd38c2"), Resource = "THIS IS THE SECOND DISCARD ANNOTATION" };
-            requests.Add(request2);
-
-            IEnumerable<Result> results = client.Audits.DiscardMultiple(requests);
-            Result resultItem = results.ElementAt(0);
-            Console.WriteLine(resultItem);
-            /*
-            {
-              "Id": "e0fb025a-d8a2-4258-91ea-c4026c1620d1",
-              "Status": 204,
-              "Annotation": "THIS IS THE FIRST DISCARD ANNOTATION"
-            }  
-            */
-            /* SNIPPET 7: END */
-        }
-        private void GetServerTime()
-        {
-            /* SNIPPET 8: START */
-            DateTime dateTime = client.GetServerTime();
-            Console.WriteLine(dateTime.ToString());
-            /*
-             23/07/2020 17:06:33
-            */
-            /* SNIPPET 8: END */
-        }
-
-        #endregion
-
-        public void Run()
-        {
-            try
-            {
-                /**** Common vars shared between different snippets: modify the following input according to your testing server *****/
-                Guid objectId = new Guid("8e3b3738-2f5f-494d-bde1-fac15da28c86");
-                Guid id1 = objectId;
-                Guid id2 = new Guid("01e025e8-0fb3-59da-a9b8-2f238c6f011c");
-
-                // Common objects are mocked to do not waste precious roundtrip time on each snippet
-                List<Command> commands = new List<Command> { new Command { CommandId = "Adjust" }, new Command { CommandId = "OperatorOverride" }, new Command(), new Command(), new Command { CommandId = "Release" } };
-
-                Guid equipmentId = new Guid("2f321415-35d9-5c48-b643-60c5132cc001");
-
-                Guid spaceId = new Guid("78c022db-f109-5a0c-86e7-d0d7d3210ea7");
-
-                MetasysObject building = new MetasysObject { Id = new Guid("2f321415-35d9-5c48-b643-60c5132cc001") };
-
-                MetasysObject sampleEquipment = new MetasysObject { Id = new Guid("0e8c034b-1586-5ed9-8455-dd33e99c2c7e") };
-
-                MetasysObject device = new MetasysObject { Id = new Guid("21c605fb-4755-5d65-8e9f-4fc8283b0366") };
-
-                AlarmFilter alarmFilter = new AlarmFilter
-                {
-                    StartTime = new DateTime(2020, 06, 01),
-                    EndTime = new DateTime(2020, 09, 30),
-                    ExcludeAcknowledged = true
-                };
-
-                Alarm alarm = new Alarm { Id = new Guid("d66cf3da-529d-4a81-9479-04834c7a2209") };
-
-                AuditFilter auditFilter = new AuditFilter
-                {
-                    StartTime = new DateTime(2020, 06, 01),
-                    EndTime = new DateTime(2020, 06, 24),
-                    OriginApplications = OriginApplicationsEnum.SystemSecurity | OriginApplicationsEnum.AuditTrails,
-                    ActionTypes = ActionTypeEnum.Subsystem | ActionTypeEnum.Command
-                };
-
-                Audit audit = new Audit { Id = new Guid("f798591b-e6d6-441f-8f7b-596fc2e6c003") };
-
-                Audit auditForAnnotation = new Audit { Id = new Guid("f179a59c-ce36-47e1-afa6-f873b80259ed") };
-
-                /********************************************************************************************************************/
-                var option = "";
-                while (option != "99")
-                {
-                    PrintMenu();
-                    Console.Write("\r\nSelect an option: ");
-                    option = Console.ReadLine();
-                    Console.WriteLine();
-                    switch (option)
-                    {
-                        case "1":
-                            TryLogin_Refresh();
-                            break;
-                        case "2":
-                            GetObjectIdentifier();
-                            break;
-                        case "3":
-                            ReadProperty(objectId);
-                            break;
-                        case "4":
-                            ReadPropertyMultiple(id1, id2);
-                            break;
-                        case "5":
-                            WriteProperty();
-                            break;
-                        case "6":
-                            WritePropertyMultiple(id1, id2);
-                            break;
-                        case "7":
-                            GetCommands(objectId);
-                            break;
-                        case "8":
-                            SendCommands(objectId, commands);
-                            break;
-                        case "9":
-                            GetNetworkDeviceTypes_GetNetworkDevices();
-                            break;
-                        case "10":
-                            GetObjects();
-                            break;
-                        case "11":
-                            Localize();
-                            break;
-                        case "12":
-                            GetSpaces();
-                            break;
-                        case "13":
-                            GetSpaceTypes();
-                            break;
-                        case "14":
-                            GetEquipment();
-                            break;
-                        case "15":
-                            GetSpaceEquipment_GetSpaceChildren(spaceId);
-                            break;
-                        case "16":
-                            GetEquipmentPoints(sampleEquipment);
-                            break;
-                        case "17":
-                            GetAlarms();
-                            break;
-                        case "18":
-                            GetSingleAlarm_GetAlarmsForAnObject_GetAlarmsForNetworkDevice(alarm, objectId, alarmFilter, device);
-                            break;
-                        case "19":
-                            GetAlarmsAnnotation(alarm);
-                            break;
-                        case "20":
-                            GetTrendedAttributes_GetSamples();
-                            break;
-                        case "21":
-                            GetAudits();
-                            break;
-                        case "22":
-                            GetSingleAudit_GetAuditsForAnObject(audit, objectId, auditFilter);
-                            break;
-                        case "23":
-                            GetAuditsAnnotation(audit);
-                            break;
-                        case "24":
-                            DiscardSingleAudit(audit);
-                            break;
-                        case "25":
-                            ChangeApiVersion();
-                            break;
-                        case "26":
-                            ChangeHostname();
-                            break;
-                        case "27":
-                            AddAuditAnnotation(auditForAnnotation);
-                            break;
-                        case "28":
-                            AddAuditAnnotationMultiple();
-                            break;
-                        case "29":
-                            DiscardAuditMultiple();
-                            break;
-                        case "30":
-                            GetServerTime();
-                            break;
-                        case "99":
-                            return; // Exit from JSON output demo
-                    }
-                    Console.WriteLine();
-                    Console.WriteLine("Press Enter to return to the JSON output menu...");
-                    Console.ReadLine();
-                    Console.WriteLine();
-                }
-            }
-            catch (Exception exception)
-            {
-                log.Logger.Error(string.Format("{0}", exception.Message));
-                Console.WriteLine("\n \nAn Error occurred. Press Enter to return to Main Menu");
-                Console.ReadLine();
-            }
-        }
-
-        private static void PrintMenu()
-        {
-            Console.Clear();
-            Console.WriteLine("Choose an option:");
-            Console.WriteLine("1) TryLogin, Refresh");
-            Console.WriteLine("2) GetObjectIdentifier");
-            Console.WriteLine("3) ReadProperty");
-            Console.WriteLine("4) ReadPropertyMultiple");
-            Console.WriteLine("5) WriteProperty");
-            Console.WriteLine("6) WritePropertyMultiple");
-            Console.WriteLine("7) GetCommands");
-            Console.WriteLine("8) SendCommand");
-            Console.WriteLine("9) GetNetworkDeviceTypes, GetNetworkDevices");
-            Console.WriteLine("10) GetObjects");
-            Console.WriteLine("11) Localize");
-            Console.WriteLine("12) GetSpaces");
-            Console.WriteLine("13) GetSpaceTypes");
-            Console.WriteLine("14) GetEquipment");
-            Console.WriteLine("15) GetSpaceEquipment, GetSpaceChildren");
-            Console.WriteLine("16) GetEquipmentPoints");
-            Console.WriteLine("17) GetAlarms");
-            Console.WriteLine("18) GetSingleAlarm, GetAlarmsForAnObject, GetAlarmsForNetworkDevice");
-            Console.WriteLine("19) GetAlarmAnnotations");
-            Console.WriteLine("20) GetTrendedAttributes, GetSamples");
-            Console.WriteLine("21) GetAudits");
-            Console.WriteLine("22) GetSingleAudit, GetAuditsForAnObject");
-            Console.WriteLine("23) GetAuditAnnotations");
-            Console.WriteLine("24) DiscardAudit");
-            Console.WriteLine("25) ChangeApiVersion");
-            Console.WriteLine("26) ChangeHostname");
-            Console.WriteLine("27) AddAuditAnnotation");
-            Console.WriteLine("28) AddAuditAnnotationMultiple");
-            Console.WriteLine("29) DiscardAuditMultiple");
-            Console.WriteLine("30) GetServerTime");
-            Console.WriteLine("99) Exit");
-        }
+              }
+              ]
+          }
+      */
+      Variant multiple1Description = multiple1.FindAttributeByName("description");
+      /* SNIPPET 2: END */
     }
+    #endregion
+
+    #region WRITE A PROPERTY
+    private void WriteProperty()
+    {
+      /* SNIPPET 1: START */
+      var id = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
+      client.WriteProperty(id, "description", "This is an AV.");
+      /* SNIPPET 1: END */
+    }
+    private void WritePropertyMultiple(ObjectId id1, ObjectId id2)
+    {
+      /* SNIPPET 2: START */
+      List<ObjectId> ids = [id1, id2];
+      // Write to many attributes values using a list of tuples
+      List<(string, object)> attributesList = new List<(string, object)> { ("description", "This is an AV.") };
+      client.WritePropertyMultiple(ids, attributesList);
+      // Write to many attributes values using a dictionary of attribute/value pairs
+      Dictionary<string, object> attributesDictionary = new Dictionary<string, object> { { "description", "This is an AV." } };
+      client.WritePropertyMultiple(ids, attributesDictionary);
+      /* SNIPPET 2: END */
+    }
+    #endregion
+
+    #region GET AND SEND COMMANDS
+    private void GetCommands(ObjectId objectId)
+    {
+      /* SNIPPET 1: START */
+      List<Command> commands = client.GetCommands(objectId).ToList();
+      Command command = commands.FindById("adjust");
+      Console.WriteLine(command);
+      /*
+          {
+            "Title": "Adjust",
+            "TitleEnumerationKey": "commandIdEnumSet.adjustCommand",
+            "CommandId": "Adjust",
+            "Items": [
+              {
+                "Title": "Value",
+                "Type": "number",
+                "EnumerationValues": null,
+                "Minimum": null,
+                "Maximum": null
+              }
+            ]
+          }
+      */
+      /* SNIPPET 1: END */
+    }
+    private void SendCommands(ObjectId objectId, List<Command> commands)
+    {
+      /* SNIPPET 2: START */
+      Command adjust = commands.FindById("adjust");
+      Command operatorOverride = commands.FindById("operatorOverride");
+      Command release = commands.FindById("release");
+      Console.WriteLine(release);
+      /*
+        {
+            "Title": "Release",
+            "TitleEnumerationKey": "commandIdEnumSet.releaseCommand",
+            "CommandId": "Release",
+            "Items": [
+              {
+                "Title": "oneOf",
+                "Type": "enum",
+                "EnumerationValues": [
+                  {
+                    "Title": "Present Value",
+                    "TitleEnumerationKey": "attributeEnumSet.presentValue"
+                  }
+                ],
+                "Minimum": 1.0,
+                "Maximum": 1.0
+              },
+              {
+                "Title": "oneOf",
+                "Type": "enum",
+                "EnumerationValues": [
+                  {
+                    "Title": "0 (No Priority)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityNone"
+                  },
+                  {
+                    "Title": "1 (Manual Life Safety)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityManualEmergency"
+                  },
+                  {
+                    "Title": "2 (Auto Life Safety)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityFireApplications"
+                  },
+                  {
+                    "Title": "3 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority3"
+                  },
+                  {
+                    "Title": "4 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority4"
+                  },
+                  {
+                    "Title": "5 (Critical Equipment)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityCriticalEquipment"
+                  },
+                  {
+                    "Title": "6 (Minimum On Off)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityMinimumOnOff"
+                  },
+                  {
+                    "Title": "7 (Heavy Equip Delay)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityHeavyEquipDelay"
+                  },
+                  {
+                    "Title": "8 (Operator Override)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityOperatorOverride"
+                  },
+                  {
+                    "Title": "9 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority9"
+                  },
+                  {
+                    "Title": "10 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority10"
+                  },
+                  {
+                    "Title": "11 (Demand Limiting)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityDemandLimiting"
+                  },
+                  {
+                    "Title": "12 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority12"
+                  },
+                  {
+                    "Title": "13 (Load Rolling)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityLoadRolling"
+                  },
+                  {
+                    "Title": "14 (Application)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priority14"
+                  },
+                  {
+                    "Title": "15 (Scheduling)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.prioritySchedulingOst"
+                  },
+                  {
+                    "Title": "16 (Default)",
+                    "TitleEnumerationKey": "writePriorityEnumSet.priorityDefault"
+                  }
+                ],
+                "Minimum": 1.0,
+                "Maximum": 1.0
+              }
+            ]
+          }
+      */
+      var list1 = new List<object> { 70 };
+      client.SendCommand(objectId, adjust.CommandId, list1);
+      var list2 = new List<object> { 75 };
+      client.SendCommand(objectId, operatorOverride.CommandId, list2);
+      var list3 = new List<object> { "attributeEnumSet.presentValue", "writePriorityEnumSet.priorityNone" };
+      client.SendCommand(objectId, release.CommandId, list3);
+      /* SNIPPET 2: END */
+    }
+    #endregion
+
+    #region GET NETWORK DEVICES AND OBJECT CHILDREN
+    private void GetNetworkDeviceTypes_GetNetworkDevices()
+    {
+      /* SNIPPET 1: START */
+      List<MetasysObjectType> types = client.GetNetworkDeviceTypes().ToList();
+      Console.WriteLine(types[0]);
+      /*
+      {
+        "Description": "NAE55-NIE59",
+        "DescriptionEnumerationKey": "objectTypeEnumSet.n50Class",
+        "Id": 185
+      }
+      */
+      int type1 = types[0].Id;
+      List<MetasysObject> devices = client.GetNetworkDevices(type1.ToString()).ToList();
+      MetasysObject device = devices.LastOrDefault();
+      Console.WriteLine(device);
+      /*
+          {
+            "ItemReference": "Win2016-VM2:vNAE2343996",
+            "Id": "142558f8-c4c7-5f89-be97-d806adb72053",
+            "Name": "vNAE2343996",
+            "Description": "",
+            "Type": null,
+            "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/185",
+            "Category": null,
+            "Children": [],
+            "ChildrenCount": 0
+          }
+      */
+
+      List<MetasysObject> devices2 = client.GetNetworkDevices(NetworkDeviceTypeEnum.SNC).ToList();
+      MetasysObject device2 = devices2.LastOrDefault();
+      Console.WriteLine(device2);
+      /*
+          {
+            "ItemReference": "WIN-21DJ9JV9QH6:EECMI-SNC-KNX",
+            "Id": "69b3c2a5-1090-5418-afd9-5efc7186e42f",
+            "Name": "EECMI-SNC-KNX",
+            "Description": "",
+            "Type": null,
+            "TypeUrl": "https://win-21dj9jv9qh6/api/v3/enumSets/508/members/448",
+            "ObjectType": null,
+            "Category": null,
+            "Children": [],
+            "ChildrenCount": 0
+          }
+      */
+
+
+      /* SNIPPET 1: END */
+    }
+
+    private void GetObjects()
+    {
+      /* SNIPPET 2: START */
+      var parentId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB");
+      // Get direct children (1 level)
+      List<MetasysObject> directChildren = client.GetObjects(parentId).ToList();
+      MetasysObject lastChild = directChildren.LastOrDefault();
+      Console.WriteLine(lastChild);
+      /*
+          {
+            "ItemReference": "Win2016-VM2:vNAE2343996/Field Bus MSTP1.VAV-08.ZN-T",
+            "Id": "d5d96cd3-db4a-52e0-affd-8bc3393c30ec",
+            "Name": "ZN-T",
+            "Description": null,
+            "Type": null,
+            "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/601",
+            "Category": null,
+            "Children": [],
+            "ChildrenCount": 0
+          }
+         */
+      // Get direct children (1 level) with internal objects
+      directChildren = client.GetObjects(parentId, includeInternalObjects: true).ToList();
+      // Get descendant for 2 levels (it could take long time, depending on the number of objects)
+      List<MetasysObject> level2Descendants = client.GetObjects(parentId, 2).ToList();
+      MetasysObject level1Parent = level2Descendants.FindByName("Time");
+      Console.WriteLine(level1Parent);
+      /*
+        {
+          "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time",
+          "Id": "22bb952e-7557-5de9-b7e5-dce39e21addd",
+          "Name": "Time",
+          "Description": null,
+          "Type": null,
+          "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/176",
+          "Category": null,
+          "Children": [
+          {
+              "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Day",
+              "Id": "5886a93f-9260-553c-995e-6a65374de85d",
+              "Name": "Day",
+              "Description": null,
+              "Type": null,
+              "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
+              "Category": null,
+              "Children": [],
+              "ChildrenCount": 0
+          },
+          {
+              "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Hour",
+              "Id": "6a50d3af-d0a2-537c-a2f7-9c1b5f271cc5",
+              "Name": "Hour",
+              "Description": null,
+              "Type": null,
+              "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
+              "Category": null,
+              "Children": [],
+              "ChildrenCount": 0
+          },
+          {
+              "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Minute",
+              "Id": "19a53f38-2fd7-5ac3-a12c-f3b9704ac194",
+              "Name": "Minute",
+              "Description": null,
+              "Type": null,
+              "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
+              "Category": null,
+              "Children": [],
+              "ChildrenCount": 0
+          },
+          {
+              "ItemReference": "Win2016-VM2:vNAE2343996/WeatherForecast.Time.Year",
+              "Id": "74dfc214-22c1-57a7-ace5-606636d0049c",
+              "Name": "Year",
+              "Description": null,
+              "Type": null,
+              "TypeUrl": "https://win2016-vm2/api/v2/enumSets/508/members/165",
+              "Category": null,
+              "Children": [],
+              "ChildrenCount": 0
+          }
+          ],
+          "ChildrenCount": 4
+      }
+         */
+      /* SNIPPET 2: END */
+    }
+    #endregion
+
+    #region LOCALIZATION OF METASYS ENUMERATIONS
+    private void Localize()
+    {
+      /* SNIPPET 1: START */
+      client.Culture = new CultureInfo("en-US");
+      /* SNIPPET 1: END */
+
+      /* SNIPPET 2: START */
+      // Access from the client object (uses client.Culture as input)
+      string translated = client.Localize("reliabilityEnumSet.reliable");
+      Console.WriteLine(translated);
+      /*
+          Reliable
+        */
+      // Access without instantiating a client
+      translated = ResourceManager.Localize("reliabilityEnumSet.reliable",
+          new CultureInfo("it-IT"));
+      Console.WriteLine(translated);
+      /*
+          Affidabile
+        */
+      /* SNIPPET 2: END */
+    }
+    #endregion
+
+    #region SPACES AND EQUIPMENT
+    private void GetSpaces()
+    {
+      /* SNIPPET 1: START */
+      // Retrieves the list of Buildings using SpaceTypeEnum helper
+      List<MetasysObject> buildings = client.GetSpaces(SpaceTypeEnum.Building).ToList();
+      MetasysObject building = buildings.LastOrDefault();
+      Console.WriteLine(building);
+      /*
+          {
+            "ItemReference": "Win2016-VM2:Win2016-VM2/JCI.Building 1",
+            "Id": "164aaba2-0fb3-5b5d-bfe9-49cf6b797c93",
+            "Name": "North America (BACnet)",
+            "Description": null,
+            "Type": 2,
+            "TypeUrl": "https://win2016-vm2/api/v2/enumSets/1766/members/1",
+            "Category": "Building",
+            "Children": [],
+            "ChildrenCount": 0
+          }
+       */
+      // Retrieves all the spaces in a flat hierarchy
+      List<MetasysObject> spaces = client.GetSpaces().ToList();
+      MetasysObject firstSpace = spaces.FirstOrDefault();
+      Console.WriteLine(firstSpace);
+      /*
+          {
+            "ItemReference": "Win2016-VM2:Win2016-VM2/JCI.Building 1.Floor 1.Milwaukee.507 E Michigan Street Campus",
+            "Id": "896ba096-db3c-5038-8505-636785906cca",
+            "Name": "507 E Michigan Street Campus",
+            "Description": null,
+            "Type": 2,
+            "TypeUrl": "https://win2016-vm2/api/v2/enumSets/1766/members/3",
+            "Category": "Room",
+            "Children": [],
+            "ChildrenCount": 0
+          }
+       */
+      /* SNIPPET 1: END */
+    }
+
+    private void GetSpaceTypes()
+    {
+      /* SNIPPET 2: START */
+      IEnumerable<MetasysObjectType> spaceTypes = client.GetSpaceTypes();
+      foreach (var type in spaceTypes)
+      {
+        Console.WriteLine(type);
+      }
+      /*
+          {
+            "Description": "Building",
+            "DescriptionEnumerationKey": "Building",
+            "Id": 1
+          }
+          {
+            "Description": "Floor",
+            "DescriptionEnumerationKey": "Floor",
+            "Id": 2
+          }
+          {
+            "Description": "Generic",
+            "DescriptionEnumerationKey": "Generic",
+            "Id": 0
+          }
+          {
+            "Description": "Room",
+            "DescriptionEnumerationKey": "Room",
+            "Id": 3
+          }
+       */
+      /* SNIPPET 2: END */
+    }
+
+    private void GetEquipment()
+    {
+      /* SNIPPET 3: START */
+      List<MetasysObject> equipment = client.GetEquipment().ToList();
+      MetasysObject sampleEquipment = equipment.FirstOrDefault();
+      Console.WriteLine(sampleEquipment);
+      /*
+           {
+            "ItemReference": "Win2016-VM2:Win2016-VM2/equipment.vNAE2343947.Field Bus MSTP1.AHU-07",
+            "Id": "6c6e18b8-015f-572a-814c-1e5d66142850",
+            "Name": "AHU-07",
+            "Description": null,
+            "Type": 3,
+            "TypeUrl": null,
+            "Category": null,
+            "Children": [],
+            "ChildrenCount": 0
+          }
+       */
+      /* SNIPPET 3: END */
+
+    }
+
+    private void GetSpaceEquipment_GetSpaceChildren(Guid spaceId)
+    {
+      /* SNIPPET 4: START */
+      IEnumerable<MetasysObject> spaceEquipment = client.GetSpaceEquipment(spaceId);
+
+      IEnumerable<MetasysObject> spaceChildren = client.GetSpaceChildren(spaceId);
+      MetasysObject sampleSpaceEquipment = spaceEquipment.FirstOrDefault();
+      /* SNIPPET 4: END */
+    }
+
+    private void GetEquipmentPoints(MetasysObject sampleEquipment)
+    {
+      /* SNIPPET 5: START */
+      IEnumerable<MetasysPoint> equipmentPoints = client.GetEquipmentPoints(new Guid(sampleEquipment.Id));
+      MetasysPoint point = equipmentPoints.FindByShortName("Analog Input-1");
+      string presentValue = point.PresentValue?.StringValue;
+      Console.WriteLine(point);
+      /*
+          {
+            "EquipmentName": "AHU-07",
+            "ShortName": "CLG-O",
+            "Label": "Cooling Output",
+            "Category": "",
+            "IsDisplayData": true,
+            "ObjectId": "9dd107cf-e8dc-583a-9557-813395ae1971",
+            "AttributeUrl": "https://win2016-vm2/api/v2/enumSets/509/members/85",
+            "ObjectUrl": "https://win2016-vm2/api/v2/objects/9dd107cf-e8dc-583a-9557-813395ae1971",
+            "PresentValue": {
+              "StringValue": "0",
+              "StringValueEnumerationKey": null,
+              "NumericValue": 0.0,
+              "BooleanValue": false,
+              "ArrayValue": null,
+              "Attribute": "presentValue",
+              "Id": "9dd107cf-e8dc-583a-9557-813395ae1971",
+              "Reliability": "Reliable",
+              "ReliabilityEnumerationKey": "reliabilityEnumSet.reliable",
+              "Priority": "0 (No Priority)",
+              "PriorityEnumerationKey": "writePriorityEnumSet.priorityNone",
+              "IsReliable": true
+            }
+          }
+       */
+      /* SNIPPET 5: END */
+    }
+    #endregion
+
+    #region ALARMS
+    private void GetAlarms()
+    {
+      /* SNIPPET 1: START */
+      AlarmFilter alarmFilter = new AlarmFilter
+      {
+        StartTime = new DateTime(2020, 6, 1),
+        EndTime = new DateTime(2020, 6, 18),
+        ExcludeAcknowledged = true
+      };
+      PagedResult<Alarm> alarmsPager = client.Alarms.Get(alarmFilter);
+      // Prints the number of records fetched and paging information
+      Console.WriteLine("Total:" + alarmsPager.Total);
+      Console.WriteLine("Current page:" + alarmsPager.CurrentPage);
+      Console.WriteLine("Page size:" + alarmsPager.PageSize);
+      Console.WriteLine("Pages:" + alarmsPager.PageCount);
+      /* Console Output: Start
+          Total:4611
+          Current page:1
+          Page size:100
+          Pages:47
+      Console Output: End */
+      Alarm alarm = alarmsPager.Items.ElementAt(0);
+      Console.WriteLine(alarm);
+      /* Console Output: Start
+      {
+        "Self": "https://win-21dj9jv9qh6/api/v3/alarms/e03d81f9-69de-48e8-92d7-81167df19f6c",
+        "Id": "e03d81f9-69de-48e8-92d7-81167df19f6c",
+        "ItemReference": "WIN-21DJ9JV9QH6:EECMI-NCE25-3",
+        "Name": "EECMI-NCE25-3",
+        "Message": "WIN-21DJ9JV9QH6:EECMI-NCE25-3 is offline",
+        "IsAckRequired": true,
+        "TypeUrl": null,
+        "Type": "alarmValueEnumSet.avOffline",
+        "Priority": 106,
+        "TriggerValue": {
+          "Value": "",
+          "UnitsUrl": null,
+          "Units": "unitEnumSet.noUnits"
+        },
+        "CreationTime": "2020-06-17T11:22:30Z",
+        "IsAcknowledged": false,
+        "IsDiscarded": false,
+        "CategoryUrl": null,
+        "Category": "objectCategoryEnumSet.systemCategory",
+        "ObjectUrl": "https://win-21dj9jv9qh6/api/v3/objects/e03d81f9-69de-48e8-92d7-81167df19f6c",
+        "AnnotationsUrl": "https://win-21dj9jv9qh6/api/v3/alarms/e03d81f9-69de-48e8-92d7-81167df19f6c/annotations"
+      }
+      Console Output: End */
+      /* SNIPPET 1: END */
+    }
+
+    private void GetSingleAlarm_GetAlarmsForAnObject_GetAlarmsForNetworkDevice(Alarm alarm, Guid objectId, AlarmFilter alarmFilter, MetasysObject device)
+    {
+      /* SNIPPET 2: START */
+      Alarm singleAlarm = client.Alarms.FindById(alarm.Id);
+      PagedResult<Alarm> objectAlarms = client.Alarms.GetForObject(objectId, alarmFilter);
+      PagedResult<Alarm> deviceAlarms = client.Alarms.GetForNetworkDevice(device.Id, alarmFilter);
+      /* SNIPPET 2: END */
+    }
+
+    private void GetAlarmsAnnotation(Alarm alarm)
+    {
+      /* SNIPPET 3: START */
+      IEnumerable<AlarmAnnotation> annotations = client.Alarms.GetAnnotations(alarm.Id);
+      AlarmAnnotation firstAnnotation = annotations.FirstOrDefault();
+      Console.WriteLine(firstAnnotation);
+      /*
+      {
+          "AlarmUrl": "https://win-ervotujej94/api/v2/alarms/f0f64d5c-b70e-8754-836c-1ac99182f4e4",
+          "Text": "Test Annotation 00",
+          "User": "metasyssysagent",
+          "CreationTime": "2020-05-27T06:21:31Z",
+          "Action": "none"
+      }
+      */
+      /* SNIPPET 3: END */
+    }
+    #endregion
+
+    #region TRENDS
+    private void GetTrendedAttributes_GetSamples()
+    {
+      /* SNIPPET 1: START */
+      var trendedObjectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
+      // Get attributes where trend extension is configured
+      List<MetasysAttribute> trendedAttributes = client.Trends.GetTrendedAttributes(trendedObjectId);
+      int attributeId = trendedAttributes[0].Id;
+      TimeFilter timeFilter = new TimeFilter
+      {
+        StartTime = new DateTime(2020, 6, 5),
+        EndTime = new DateTime(2020, 6, 6)
+      };
+      PagedResult<Sample> samplesPager = client.Trends.GetSamples(trendedObjectId, attributeId, timeFilter);
+      // Prints the number of records fetched and paging information
+      Console.WriteLine("Total:" + samplesPager.Total);
+      Console.WriteLine("Current page:" + samplesPager.CurrentPage);
+      Console.WriteLine("Page size:" + samplesPager.PageSize);
+      Console.WriteLine("Pages:" + samplesPager.PageCount);
+      /*
+          Total:145
+          Current page:1
+          Page size:100
+          Pages:2
+       */
+      Sample firstSample = samplesPager.Items.FirstOrDefault();
+      Console.WriteLine(firstSample);
+      /*
+          {
+            "Value": 82.0,
+            "Unit": "deg F",
+            "Timestamp": "2020-05-12T05:00:00Z",
+            "IsReliable": true
+          }
+        */
+      /* SNIPPET 1: END */
+    }
+    #endregion
+
+    #region AUDITS
+    private void GetAudits()
+    {
+      /* SNIPPET 1: START */
+      AuditFilter auditFilter = new AuditFilter
+      {
+        StartTime = new DateTime(2020, 06, 01),
+        EndTime = new DateTime(2020, 06, 24),
+        OriginApplications = OriginApplicationsEnum.SystemSecurity | OriginApplicationsEnum.AuditTrails,
+        ActionTypes = ActionTypeEnum.Subsystem | ActionTypeEnum.Command
+      };
+      PagedResult<Audit> auditsPager = client.Audits.Get(auditFilter);
+      // Prints the number of records fetched and paging information
+      Console.WriteLine("Total:" + auditsPager.Total);
+      Console.WriteLine("Current page:" + auditsPager.CurrentPage);
+      Console.WriteLine("Page size:" + auditsPager.PageSize);
+      Console.WriteLine("Pages:" + auditsPager.PageCount);
+      /*
+          Total:323
+          Current page:1
+          Page size:100
+          Pages:4
+       */
+      Audit audit = auditsPager.Items.FirstOrDefault();
+      Console.WriteLine(audit);
+      /*
+      {
+        "Id": "8e3b3738-2f5f-494d-bde1-fac15da28c86",
+        "CreationTime": "2020-06-23T16:45:54.697Z",
+        "ActionTypeUrl": null,
+        "ActionType": "auditActionTypeEnumSet.subsystemAuditActionType",
+        "Discarded": false,
+        "StatusUrl": null,
+        "Status": null,
+        "PreData": null,
+        "PostData": "::1",
+        "Parameters": "[]",
+        "ErrorString": null,
+        "User": "testuser",
+        "Signature": null,
+        "ObjectUrl": "https://win-21dj9jv9qh6/api/v3/objects/1949c631-7823-5230-b951-aae3f8c9d64a",
+        "AnnotationsUrl": null,
+        "Legacy": {
+          "FullyQualifiedItemReference": "WIN-21DJ9JV9QH6:WIN-21DJ9JV9QH6",
+          "ItemName": "EECMI-ADS11",
+          "ClassLevel": "auditClassesEnumSet.userActionAuditClass",
+          "OriginApplication": "auditOriginAppEnumSet.systemSecurityAuditOriginApp",
+          "Description": "auditTrailStringsEnumSet.atstrSecurityUserLoginSuccessful"
+        },
+        "Self": "https://win-21dj9jv9qh6/api/v3/audits/8e3b3738-2f5f-494d-bde1-fac15da28c86"
+      }
+       */
+      /* SNIPPET 1: END */
+    }
+
+    private void GetSingleAudit_GetAuditsForAnObject(Audit audit, Guid objectId, AuditFilter auditFilter)
+    {
+      /* SNIPPET 2: START */
+      Audit singleAudit = client.Audits.FindById(audit.Id);
+      PagedResult<Audit> objectAudits = client.Audits.GetForObject(objectId, auditFilter);
+      /* SNIPPET 2: END */
+    }
+
+    private void GetAuditsAnnotation(Audit audit)
+    {
+      /* SNIPPET 3: START */
+      Guid auditId = new Guid("f798591b-e6d6-441f-8f7b-596fc2e6c003");
+      IEnumerable<AuditAnnotation> annotations = client.Audits.GetAnnotations(auditId);
+      AuditAnnotation firstAnnotation = annotations.FirstOrDefault();
+      Console.WriteLine(firstAnnotation);
+      /*
+      {
+          "auditUrl": "https://win-ervotujej94/api/v2/audits/40aff6ec-ecb2-4b65-a504-0ac659756956",
+          "creationTime": "2020-06-05T15:58:40.407Z",
+          "user": "MetasysSysAgent",
+          "text": "TEST AUDIT ANNOTATION 02",
+          "signature": null,
+          "action": "none"
+      }
+      */
+      /* SNIPPET 3: END */
+    }
+
+    private void DiscardSingleAudit(Audit audit)
+    {
+
+      /* SNIPPET 4: START */
+      string annotationText = "Reason why the audit has been discarded";
+      client.Audits.Discard(audit.Id, annotationText);
+      /* SNIPPET 4: END */
+    }
+
+    private void AddAuditAnnotation(Audit audit)
+    {
+      /* SNIPPET 5: START */
+      string annotationText = "This is the text of the annotation";
+      client.Audits.AddAnnotation(audit.Id, annotationText);
+      /* SNIPPET 5: END */
+    }
+
+    private void AddAuditAnnotationMultiple()
+    {
+      /* SNIPPET 6: START */
+      var requests = new List<BatchRequestParam>();
+      BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("f179a59c-ce36-47e1-afa6-f873b80259ed"), Resource = "THIS IS THE FIRST AUDIT ANNOTATION" };
+      requests.Add(request1);
+      BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("bccc567c-300b-4d38-894c-104cdd6e2836"), Resource = "THIS IS THE SECOND AUDIT ANNOTATION" };
+      requests.Add(request2);
+
+      IEnumerable<Result> results = client.Audits.AddAnnotationMultiple(requests);
+      Result resultItem = results.ElementAt(0);
+      Console.WriteLine(resultItem);
+      /*
+      {
+        "Id": "e0fb025a-d8a2-4258-91ea-c4026c1620d1",
+        "Status": 201,
+        "Annotation": "THIS IS THE FIRST AUDIT ANNOTATION"
+      }            /*
+      */
+      /* SNIPPET 6: END */
+    }
+    private void DiscardAuditMultiple()
+    {
+
+      /* SNIPPET 7: START */
+      var requests = new List<BatchRequestParam>();
+      BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("030d3998-3145-44d9-b378-886e52d373c1"), Resource = "THIS IS THE FIRST DISCARD ANNOTATION" };
+      requests.Add(request1);
+      BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("181a6677-ccbd-4b97-9438-5b331ffd38c2"), Resource = "THIS IS THE SECOND DISCARD ANNOTATION" };
+      requests.Add(request2);
+
+      IEnumerable<Result> results = client.Audits.DiscardMultiple(requests);
+      Result resultItem = results.ElementAt(0);
+      Console.WriteLine(resultItem);
+      /*
+      {
+        "Id": "e0fb025a-d8a2-4258-91ea-c4026c1620d1",
+        "Status": 204,
+        "Annotation": "THIS IS THE FIRST DISCARD ANNOTATION"
+      }
+      */
+      /* SNIPPET 7: END */
+    }
+    private void GetServerTime()
+    {
+      /* SNIPPET 8: START */
+      DateTime dateTime = client.GetServerTime();
+      Console.WriteLine(dateTime.ToString());
+      /*
+       23/07/2020 17:06:33
+      */
+      /* SNIPPET 8: END */
+    }
+
+    #endregion
+
+    public void Run()
+    {
+      try
+      {
+        /**** Common vars shared between different snippets: modify the following input according to your testing server *****/
+        Guid objectId = new Guid("8e3b3738-2f5f-494d-bde1-fac15da28c86");
+        Guid id1 = objectId;
+        Guid id2 = new Guid("01e025e8-0fb3-59da-a9b8-2f238c6f011c");
+
+        // Common objects are mocked to do not waste precious roundtrip time on each snippet
+        List<Command> commands = new List<Command> { new Command { CommandId = "Adjust" }, new Command { CommandId = "OperatorOverride" }, new Command(), new Command(), new Command { CommandId = "Release" } };
+
+        Guid equipmentId = new Guid("2f321415-35d9-5c48-b643-60c5132cc001");
+
+        Guid spaceId = new Guid("78c022db-f109-5a0c-86e7-d0d7d3210ea7");
+
+        MetasysObject building = new MetasysObject { Id = new Guid("2f321415-35d9-5c48-b643-60c5132cc001") };
+
+        MetasysObject sampleEquipment = new MetasysObject { Id = new Guid("0e8c034b-1586-5ed9-8455-dd33e99c2c7e") };
+
+        MetasysObject device = new MetasysObject { Id = new Guid("21c605fb-4755-5d65-8e9f-4fc8283b0366") };
+
+        AlarmFilter alarmFilter = new AlarmFilter
+        {
+          StartTime = new DateTime(2020, 06, 01),
+          EndTime = new DateTime(2020, 09, 30),
+          ExcludeAcknowledged = true
+        };
+
+        Alarm alarm = new Alarm { Id = new Guid("d66cf3da-529d-4a81-9479-04834c7a2209") };
+
+        AuditFilter auditFilter = new AuditFilter
+        {
+          StartTime = new DateTime(2020, 06, 01),
+          EndTime = new DateTime(2020, 06, 24),
+          OriginApplications = OriginApplicationsEnum.SystemSecurity | OriginApplicationsEnum.AuditTrails,
+          ActionTypes = ActionTypeEnum.Subsystem | ActionTypeEnum.Command
+        };
+
+        Audit audit = new Audit { Id = new Guid("f798591b-e6d6-441f-8f7b-596fc2e6c003") };
+
+        Audit auditForAnnotation = new Audit { Id = new Guid("f179a59c-ce36-47e1-afa6-f873b80259ed") };
+
+        /********************************************************************************************************************/
+        var option = "";
+        while (option != "99")
+        {
+          PrintMenu();
+          Console.Write("\r\nSelect an option: ");
+          option = Console.ReadLine();
+          Console.WriteLine();
+          switch (option)
+          {
+            case "1":
+              TryLogin_Refresh();
+              break;
+            case "2":
+              GetObjectIdentifier();
+              break;
+            case "3":
+              ReadProperty(objectId);
+              break;
+            case "4":
+              ReadPropertyMultiple(id1, id2);
+              break;
+            case "5":
+              WriteProperty();
+              break;
+            case "6":
+              WritePropertyMultiple(id1, id2);
+              break;
+            case "7":
+              GetCommands(objectId);
+              break;
+            case "8":
+              SendCommands(objectId, commands);
+              break;
+            case "9":
+              GetNetworkDeviceTypes_GetNetworkDevices();
+              break;
+            case "10":
+              GetObjects();
+              break;
+            case "11":
+              Localize();
+              break;
+            case "12":
+              GetSpaces();
+              break;
+            case "13":
+              GetSpaceTypes();
+              break;
+            case "14":
+              GetEquipment();
+              break;
+            case "15":
+              GetSpaceEquipment_GetSpaceChildren(spaceId);
+              break;
+            case "16":
+              GetEquipmentPoints(sampleEquipment);
+              break;
+            case "17":
+              GetAlarms();
+              break;
+            case "18":
+              GetSingleAlarm_GetAlarmsForAnObject_GetAlarmsForNetworkDevice(alarm, objectId, alarmFilter, device);
+              break;
+            case "19":
+              GetAlarmsAnnotation(alarm);
+              break;
+            case "20":
+              GetTrendedAttributes_GetSamples();
+              break;
+            case "21":
+              GetAudits();
+              break;
+            case "22":
+              GetSingleAudit_GetAuditsForAnObject(audit, objectId, auditFilter);
+              break;
+            case "23":
+              GetAuditsAnnotation(audit);
+              break;
+            case "24":
+              DiscardSingleAudit(audit);
+              break;
+            case "25":
+              ChangeApiVersion();
+              break;
+            case "26":
+              ChangeHostname();
+              break;
+            case "27":
+              AddAuditAnnotation(auditForAnnotation);
+              break;
+            case "28":
+              AddAuditAnnotationMultiple();
+              break;
+            case "29":
+              DiscardAuditMultiple();
+              break;
+            case "30":
+              GetServerTime();
+              break;
+            case "99":
+              return; // Exit from JSON output demo
+          }
+          Console.WriteLine();
+          Console.WriteLine("Press Enter to return to the JSON output menu...");
+          Console.ReadLine();
+          Console.WriteLine();
+        }
+      }
+      catch (Exception exception)
+      {
+        log.Logger.Error(string.Format("{0}", exception.Message));
+        Console.WriteLine("\n \nAn Error occurred. Press Enter to return to Main Menu");
+        Console.ReadLine();
+      }
+    }
+
+    private static void PrintMenu()
+    {
+      Console.Clear();
+      Console.WriteLine("Choose an option:");
+      Console.WriteLine("1) TryLogin, Refresh");
+      Console.WriteLine("2) GetObjectIdentifier");
+      Console.WriteLine("3) ReadProperty");
+      Console.WriteLine("4) ReadPropertyMultiple");
+      Console.WriteLine("5) WriteProperty");
+      Console.WriteLine("6) WritePropertyMultiple");
+      Console.WriteLine("7) GetCommands");
+      Console.WriteLine("8) SendCommand");
+      Console.WriteLine("9) GetNetworkDeviceTypes, GetNetworkDevices");
+      Console.WriteLine("10) GetObjects");
+      Console.WriteLine("11) Localize");
+      Console.WriteLine("12) GetSpaces");
+      Console.WriteLine("13) GetSpaceTypes");
+      Console.WriteLine("14) GetEquipment");
+      Console.WriteLine("15) GetSpaceEquipment, GetSpaceChildren");
+      Console.WriteLine("16) GetEquipmentPoints");
+      Console.WriteLine("17) GetAlarms");
+      Console.WriteLine("18) GetSingleAlarm, GetAlarmsForAnObject, GetAlarmsForNetworkDevice");
+      Console.WriteLine("19) GetAlarmAnnotations");
+      Console.WriteLine("20) GetTrendedAttributes, GetSamples");
+      Console.WriteLine("21) GetAudits");
+      Console.WriteLine("22) GetSingleAudit, GetAuditsForAnObject");
+      Console.WriteLine("23) GetAuditAnnotations");
+      Console.WriteLine("24) DiscardAudit");
+      Console.WriteLine("25) ChangeApiVersion");
+      Console.WriteLine("26) ChangeHostname");
+      Console.WriteLine("27) AddAuditAnnotation");
+      Console.WriteLine("28) AddAuditAnnotationMultiple");
+      Console.WriteLine("29) DiscardAuditMultiple");
+      Console.WriteLine("30) GetServerTime");
+      Console.WriteLine("99) Exit");
+    }
+  }
 }

--- a/MetasysServicesExampleApp/FeaturesDemo/TrendsDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/TrendsDemo.cs
@@ -1,9 +1,6 @@
 ﻿using JohnsonControls.Metasys.BasicServices;
 using System;
 
-// Disable warnings on obsolete methods since we still want to use them (for now)
- #pragma  warning disable CS0618
-
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
     public class TrendsDemo
@@ -24,9 +21,8 @@ namespace MetasysServicesExampleApp.FeaturesDemo
                 Console.WriteLine("\nIndicate the object you want to run this example code on.");
                 Console.Write("Enter the fully qualified reference of the object (Example: \"site:device/itemReference\"): ");
                 string object1 = Console.ReadLine();
-                Guid id1 = client.GetObjectIdentifier(object1);
-                Console.WriteLine($"{object1} id: {id1}");
-                Guid objId = id1;
+                var objId = client.GetObjectIdentifier(object1);
+                Console.WriteLine($"{object1} id: {objId}");
                 var trendedAttributes = client.Trends.GetTrendedAttributes(objId);
                 Console.WriteLine(trendedAttributes[0].Description);
 

--- a/MetasysServicesExampleApp/FeaturesDemo/TrendsDemo.cs
+++ b/MetasysServicesExampleApp/FeaturesDemo/TrendsDemo.cs
@@ -1,6 +1,9 @@
 ﻿using JohnsonControls.Metasys.BasicServices;
 using System;
 
+// Disable warnings on obsolete methods since we still want to use them (for now)
+ #pragma  warning disable CS0618
+
 namespace MetasysServicesExampleApp.FeaturesDemo
 {
     public class TrendsDemo

--- a/MetasysServicesExampleApp/MetasysServicesExampleApp.csproj
+++ b/MetasysServicesExampleApp/MetasysServicesExampleApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Version>6.0.4</Version>
     <Copyright>© 2020-2024 Johnson Controls</Copyright>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -364,11 +364,11 @@ If the enumeration key is desired over the translated value use the EnumerationK
 <br/>
 
 #### Get Object Id
-In order to use most of the methods in MetasysClient the identifier (Id) of the target object must be known.  
-This Id is in the form of a Guid and can be requested using the method **`GetObjectIdentifier`** given you know the 'Fully Qualified Reference' (FQR) of the object:
+In order to use most of the methods in MetasysClient the identifier (Id) of the target object must be known.
+This Id can be requested using the method **`GetObjectIdentifier`** given you know the 'Fully Qualified Reference' (FQR) of the object:
 
 ```csharp
-Guid objectId = client.GetObjectIdentifier("Win2016-VM2:vNAE2343996/Field Bus MSTP1.VAV-08.ZN-SP");
+ObjectId objectId = client.GetObjectIdentifier("Win2016-VM2:vNAE2343996/Field Bus MSTP1.VAV-08.ZN-SP");
 Console.WriteLine(objectId);
 /*        
 d5d96cd3-db4a-52e0-affd-8bc3393c30ec
@@ -376,9 +376,19 @@ d5d96cd3-db4a-52e0-affd-8bc3393c30ec
 ```
 <br/>
 
+> [!Tip]\
+> The `ObjectId` has implicit conversions to/from `string` so in many cases you can just treat it like a string.
+> For example, in the following example we store the `objectId` in a `string` and can still pass it to `ReadProperty` which
+> expected an `ObjectId`.
+
+```csharp
+string objectId = "d5d96cd3-db4a-52e0-affd-8bc3393c30ec";
+var propertyValue = client.ReadProperty(objectId, "presentValue");
+```
+
 #### Get a Property
-In order to get a property you must know the Guid of the target object and then you can use the method **`ReadProperty`**. 
-An object called "Variant" is returned when getting a property from an object. 
+In order to get a property you must know the Id of the target object and then you can use the method **`ReadProperty`**.
+A value of type `Variant` is returned when getting a property from an object.
 Variant contains the property received in many different forms. There is a bit of intuition when handling a Variant since it will not explicitly provide the type of object received by the server. If the server cannot find the target object or attribute on the object this method will throw a MetasysHttpNotFoundException.
 ```csharp
 Variant property = client.ReadProperty(objectId, "presentValue");
@@ -405,7 +415,7 @@ To get multiple properties from multiple objects in one action use the method **
 This can be very useful if the objects all are of the same type or have the same target properties.
 
 ```csharp
-List<Guid> ids = new List<Guid> { id1, id2 };
+List<ObjectId> ids = new List<ObjectId> { id1, id2 };
 List<string> attributes = new List<string> { "name", "description", "presentValue" };
 IEnumerable<VariantMultiple> results = client.ReadPropertyMultiple(ids, attributes);
 VariantMultiple multiple1 = results.FindById(id1);
@@ -450,17 +460,17 @@ Variant multiple1Description = multiple1.FindAttributeByName("description");
 <br/>
 
 #### Write a Property
-In order to write a property you must have the Guid of the object and know the attribute name and type
-and then you have to use the method **`WriteProperty`**.  
+In order to write a property you must have the Id of the object and know the attribute name and type
+and then you have to use the method **`WriteProperty`**.
 ```csharp
-Guid id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1");
+ObjectId id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1");
 client.WriteProperty(id, "description", "This is an AV.");
 ```
 <br/>
 
 To change the same attribute values of many objects use the method **`WritePropertyMultiple`**. 
 ```csharp
-List<Guid> ids = new List<Guid> { id1, id2 };
+List<ObjectId> ids = new List<ObjectId> { id1, id2 };
 // Write to many attributes values using a list of tuples
 List<(string, object)> attributesList = new List<(string, object)> { ("description", "This is an AV.") };
 client.WritePropertyMultiple(ids, attributesList);
@@ -629,12 +639,13 @@ client.SendCommand(objectId, release.CommandId, list3);
 <br/>
 
 #### Get Children
-To get the child objects of an object use the method **`GetObjects`**.  
-This method requires the identifier (Guid) of the parent object and an optional number of levels to retrieve. 
-The default is 1 level or just the immediate children of the object. 
+To get the child objects of an object use the method **`GetObjects`**.
+This method requires the identifier of the parent object and an optional number of levels to retrieve.
+The default is 1 level or just the immediate children of the object.
 Depending on the number of objects on your server this method can take a very long time to complete.
+Starting with version 4 of the API it is much more efficient to use levels > 1 than in previous versions of the API.
 ```csharp
-Guid parentId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB");
+ObjectId parentId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB");
 // Get direct children (1 level)
 List<MetasysObject> directChildren = client.GetObjects(parentId).ToList();
 MetasysObject lastChild = directChildren.LastOrDefault();
@@ -789,15 +800,15 @@ To get a single network device use the method **`NetworkDevices.FindById`** whic
 <br/>
 
 #### Get Network Device Children
-To retrieves the collection of network devices that are children of the specified network device use the method **`NetworkDevices.GetChildren`** which return a list of Metasys Objects according to the network device Id (Guid) passed as parameter.
+To retrieves the collection of network devices that are children of the specified network device use the method **`NetworkDevices.GetChildren`** which return a list of Metasys Objects according to the network device Id passed as parameter.
 <br/>
 
 #### Get Network Devices Hosting an Equipment
-To retrieve the collection of network devices that host the specified equipment instance use the method **`NetworkDevices.GetHostingAnEquipment`** which return a list of Metasys Objects according to the equipment Id (Guid) passed as parameter.
+To retrieve the collection of network devices that host the specified equipment instance use the method **`NetworkDevices.GetHostingAnEquipment`** which return a list of Metasys Objects according to the equipment Id passed as parameter.
 <br/>
 
 #### Get Network Devices Serving a Space
-To retrieve the collection of network devices that are serving the specified space use the method **`NetworkDevices.GetServingASpace`** which return a list of Metasys Objects according to the space Id (Guid) passed as parameter.
+To retrieve the collection of network devices that are serving the specified space use the method **`NetworkDevices.GetServingASpace`** which return a list of Metasys Objects according to the space Id passed as parameter.
 <br/>
 
 
@@ -1269,7 +1280,7 @@ To get a single audit you can use the method **`Audits.FindById`** which returns
 
 #### Get Audits for an Object
 To get the audits of a specific Object you can use the method **`Audits.GetForObject`**.  
-The Guid of the parent object is required as parameter.
+The Id of the parent object is required as parameter.
 ```csharp
 AuditFilter auditFilter = new AuditFilter{};
 var objectId="17ac1932-18d8-518c-8012-420c77bea86b";
@@ -1313,12 +1324,12 @@ client.Audits.Discard(auditId, annotationText);
 > Available since API v3
 > 
 To discard multiple Audits you can use the method **`Audits.DiscardMultiple`**.  
-It takes a list of 'BatchRequestParam' objects (specifing the list of Audits Guid and annotations) and it returns a list of 'Result' objects.
+It takes a list of 'BatchRequestParam' objects (specifing the list of Audit Guids and annotations) and it returns a list of 'Result' objects.
 ```csharp
 var requests = new List<BatchRequestParam>();
-BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("e0fb025a-d8a2-4258-91ea-c4026c1620d1"), Resource = "THIS IS THE FIRST DISCARD ANNOTATION" };
+BatchRequestParam request1 = new BatchRequestParam { ObjectId = "e0fb025a-d8a2-4258-91ea-c4026c1620d1", Resource = "THIS IS THE FIRST DISCARD ANNOTATION" };
 requests.Add(request1);
-BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("5ff1341e-dbf1-4eaf-b9a1-987f51dabefa"), Resource = "THIS IS THE SECOND DISCARD ANNOTATION" };
+BatchRequestParam request2 = new BatchRequestParam { ObjectId = "5ff1341e-dbf1-4eaf-b9a1-987f51dabefa", Resource = "THIS IS THE SECOND DISCARD ANNOTATION" };
 requests.Add(request2);
 
 IEnumerable<Result> results = client.Audits.DiscardMultiple(requests);
@@ -1350,12 +1361,12 @@ client.Audits.AddAnnotation(auditId, annotationText);
 > Available since API v3
 > 
 To add multiple Annotations to an Audit you can use the method **`Audits.AddAnnotationMultiple`**.  
-It takes a list of 'BatchRequestParam' objects (specifing the list of Audits Guid and annotations) and it returns a list of 'Result' objects.
-```csharp
+It takes a list of 'BatchRequestParam' objects (specifing the list of Audit Guids and annotations) and it returns a list of 'Result' objects.
+```sharp
 var requests = new List<BatchRequestParam>();
-BatchRequestParam request1 = new BatchRequestParam { ObjectId = new Guid("e0fb025a-d8a2-4258-91ea-c4026c1620d1"), Resource = "THIS IS THE FIRST AUDIT ANNOTATION" };
+BatchRequestParam request1 = new BatchRequestParam { ObjectId = "e0fb025a-d8a2-4258-91ea-c4026c1620d1", Resource = "THIS IS THE FIRST AUDIT ANNOTATION" };
 requests.Add(request1);
-BatchRequestParam request2 = new BatchRequestParam { ObjectId = new Guid("5ff1341e-dbf1-4eaf-b9a1-987f51dabefa"), Resource = "THIS IS THE SECOND AUDIT ANNOTATION" };
+BatchRequestParam request2 = new BatchRequestParam { ObjectId = "5ff1341e-dbf1-4eaf-b9a1-987f51dabefa", Resource = "THIS IS THE SECOND AUDIT ANNOTATION" };
 requests.Add(request2);
 
 IEnumerable<Result> results = client.Audits.AddAnnotationMultiple(requests);
@@ -1378,10 +1389,10 @@ All services about trends are provided by **`Trends`** local instance of Metasys
 <br/>
 
 #### Get Object Trended Attributes
-To get the trended attributes of a specified Metasys object you can use the method **`Trends.GetTrendedAttributes`**.  
-This method requires the object Id (Guid) as parameter and it returns a list of 'MetasysAttribute' objects.
+To get the trended attributes of a specified Metasys object you can use the method **`Trends.GetTrendedAttributes`**.
+This method requires the object Id as parameter and it returns a list of 'MetasysAttribute' objects.
 ```csharp
-Guid trendedObjectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
+ObjectId trendedObjectId = client.GetObjectIdentifier("WIN-21DJ9JV9QH6:EECMI-NCE25-2/FCB.10FEC11 - V6 Unit.E4 Network Outdoor Temperature");
 
 // Get attributes where trend extension is configured
 List<MetasysAttribute> trendedAttributes = client.Trends.GetTrendedAttributes(trendedObjectId);
@@ -1389,8 +1400,8 @@ List<MetasysAttribute> trendedAttributes = client.Trends.GetTrendedAttributes(tr
 <br/>
 
 #### Get Samples
-To get the samples related the a trended attribute of an object you can use the method **`Trends.GetSamples`**.  
-This method requires the object Id (Guid), the attribute Id (numeric or enumerated value) and a 'TimeFilter' object. 
+To get the samples related the a trended attribute of an object you can use the method **`Trends.GetSamples`**.
+This method requires the object Id, the attribute Id (numeric or enumerated value) and a 'TimeFilter' object.
 It returns a 'PagedResult' list of 'Sample' objects.
 ```csharp
 int attributeId = trendedAttributes[0].Id;
@@ -1431,14 +1442,14 @@ If you try to retrieve values from an object that has no valid trended attribute
 > Available since API v3
 > 
 To the trended attributes of a specified network device you can use the method **`Trends.GetNetDevTrendedAttributes`**.
-This method requires the network device Id (Guid) as parameter and it returns a list of 'MetasysAttribute' objects.
+This method requires the network device Id as parameter and it returns a list of 'MetasysAttribute' objects.
 <br/>
 
 #### Get Network Device Samples
 > Available since API v3
-> 
-To get the samples related the a trended attribute of a network device you can use the method **`Trends.GetNetDevSamples`**.  
-This method requires the object Id (Guid), the attribute Id (numeric or enumerated value) and a 'TimeFilter' object. 
+>
+To get the samples related the a trended attribute of a network device you can use the method **`Trends.GetNetDevSamples`**.
+This method requires the object Id, the attribute Id (numeric or enumerated value) and a 'TimeFilter' object.
 It returns a 'PagedResult' list of 'Sample' objects.
 <br/>
 
@@ -1584,7 +1595,7 @@ In the Activity filter you can specify parameters as:
 
 #### Multiple Actions
 This method **`Activities.ActionMultiple`** is useful to perform batch actions as discard/acknowledge an alarm/audit given a list of requests containing the info necessary to perform the actions.
-It takes a list of 'BatchRequestParam' objects (specifing the list of Audit or Alarm Guids and annotations) and it returns a list of 'Result' objects.
+It takes a list of 'BatchRequestParam' objects (specifying the list of Audit or Alarm Guids and annotations) and it returns a list of 'Result' objects.
 
 ## Usage (COM)
 
@@ -1643,9 +1654,9 @@ Set token = client.TryLogin("vault-target")
 ### Metasys Objects
 
 #### Get Object Id
-In order to use most of the methods in LegacyMetasysClient the id of the target object must be known. 
-To retrieve the identifier of an object use the method **`GetObjectIdentifier`**.  
-This method requires the Fully Qualified Reference (FQR) of the object and returns the id as a string (in the form of a Guid).
+In order to use most of the methods in LegacyMetasysClient the id of the target object must be known.
+To retrieve the identifier of an object use the method **`GetObjectIdentifier`**.
+This method requires the Fully Qualified Reference (FQR) of the object and returns the id as a string.
 
 ```vb
 Dim id As String
@@ -1654,8 +1665,8 @@ id = client.GetObjectIdentifier("siteName:naeName/Folder1.AV1")
 <br/>
 
 #### Get a Property
-In order to get a property you must know the Guid of the target object and then you can use the method **`ReadProperty`**. 
-An object called "ComVariant" is returned when getting a property from an object. 
+In order to get a property you must know the Id of the target object and then you can use the method **`ReadProperty`**.
+An object called "ComVariant" is returned when getting a property from an object.
 ```vb
 Dim result As ComVariant
 Set result = client.ReadProperty(id, "presentValue")
@@ -1690,8 +1701,8 @@ variants=id1.Variants
 
 #### Write a Property
 
-In order to write a property you must have the Guid of the object and know the attribute name and type
-and then you have to use the method **`WriteProperty`**. 
+In order to write a property you must have the Id of the object and know the attribute name and type
+and then you have to use the method **`WriteProperty`**.
 
 ```vb
 Dim id As String
@@ -2005,7 +2016,7 @@ To get a single audit you can use the method **`GetSingleAudit`** which returns 
 
 #### Get Audits for an Object
 To get the audits of a specific Object you can use the method **`GetAuditsForAnObject`**.  
-The Guid of the parent object is required as parameter.
+The Id of the parent object is required as parameter.
 ```vb
 Set objectAuditsPager = client.GetAuditsForAnObject(objId, filter)
 Dim objectAudits() As Object
@@ -2108,7 +2119,7 @@ attrs = client.GetTrendedAttributes(objId)
 
 #### Get Samples
 To get the samples related the a trended attribute of an object you can use the method **`GetSamples`**.  
-This method requires the object Id (Guid), the attribute Id (numeric or enumerated value) and a 'ComTimeFilter' object. 
+This method requires the object Id, the attribute Id (numeric or enumerated value) and a 'ComTimeFilter' object. 
 It returns a 'ComPagedResult' list of 'ComSample' objects.
 ```vb
 Dim attr As ComAttribute
@@ -2149,7 +2160,7 @@ This method requires the network device Id as parameter and it returns a list of
 > Available since API v3
 > 
 To get the samples related the a trended attribute of a network device you can use the method **`GetNetDevSamples`**.  
-This method requires the object Id (Guid), the attribute Id (numeric or enumerated value) and a 'ComTimeFilter' object. 
+This method requires the object Id, the attribute Id (numeric or enumerated value) and a 'ComTimeFilter' object. 
 It returns a 'ComPagedResult' list of 'ComSample' objects.
 <br/>
 

--- a/TestClient/Forms/Objects.cs
+++ b/TestClient/Forms/Objects.cs
@@ -3,8 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-// Disable warnings on obsolete methods since we still want to test them
-#pragma  warning disable CS0618
+
 namespace MetasysServices_TestClient.Forms
 {
     public partial class Objects : Form

--- a/TestClient/Forms/Objects.cs
+++ b/TestClient/Forms/Objects.cs
@@ -3,7 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-
+// Disable warnings on obsolete methods since we still want to test them
+#pragma  warning disable CS0618
 namespace MetasysServices_TestClient.Forms
 {
     public partial class Objects : Form

--- a/WeatherForecastApp/Program.cs
+++ b/WeatherForecastApp/Program.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-// Disable warnings on obsolete methods since we still want to use them (for now)
-#pragma  warning disable CS0618
-
 namespace WeatherForecastApp
 {
     class Program

--- a/WeatherForecastApp/Program.cs
+++ b/WeatherForecastApp/Program.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+// Disable warnings on obsolete methods since we still want to use them (for now)
+#pragma  warning disable CS0618
+
 namespace WeatherForecastApp
 {
     class Program
@@ -33,7 +36,7 @@ namespace WeatherForecastApp
             var secureContainer = CredentialUtil.GetCredential(containerTarget);
 
             // Get parent object of Weather Forecast to retrieve related children (securely stored in Credential Manager)
-            Guid parentObjectId = metasysClient.GetObjectIdentifier(CredentialUtil.convertToUnSecureString(secureContainer.Password));
+            var parentObjectId = metasysClient.GetObjectIdentifier(CredentialUtil.convertToUnSecureString(secureContainer.Password));
             IEnumerable<MetasysObject> weatherForecast = metasysClient.GetObjects(parentObjectId, 1);
             // Retrieve latitude and longitude to get weather forecast
             MetasysObject latitudePoint = weatherForecast.FindByName("Latitude");
@@ -46,7 +49,7 @@ namespace WeatherForecastApp
             // Forecast API key is securely stored in Credential manager
             var apiKeyTarget = config.GetSection("CredentialManager:Targets:OpenWeather").Value;
             var secureApiKey = CredentialUtil.GetCredential(apiKeyTarget);
-            // Get Next Five Days forecast every 3 hours           
+            // Get Next Five Days forecast every 3 hours
             OpenWeatherMapClient weatherMapclient = new OpenWeatherMapClient(CredentialUtil.convertToUnSecureString(secureApiKey.Password));
             ForecastResult forecastResult = weatherMapclient.GetForecast(latitude, longitude).GetAwaiter().GetResult();
             // Get the closest forecast to be written
@@ -81,7 +84,7 @@ namespace WeatherForecastApp
             }
             else
             {
-                // Reset values in case there is no rain 
+                // Reset values in case there is no rain
                 metasysClient.SendCommand(Rain.Id, adjustCommand, new List<object> { 0 });
             }
             if (forecast.snow != null)


### PR DESCRIPTION
This will be slightly easier to review one commit at a time. Only the first one is large. But 90% of it is changing type from Guid to ObjectId or converting guid to/from objectid

It was a mistake that we started using `Guid` for object identifiers in this library. The Metasys REST API makes no guarantee that the ids it returns will be Guids. It has never documented them as such. (For example see [Get an object](https://jci-metasys.github.io/api-landing/api/v5#tag/objects/operation/getObject) and examine the `objectId` parameter.)

This PR starts the transition away from using `Guid`

- Introduce new `ObjectId` type which has implicit conversions to/from `string` and to/from `Guid` to aid the transition to the new methods. The new type was used (instead of just using `string`) as I think it makes the APIs slightly easier to understand. But it also allowed us to create implicit conversions so that the changes could be made without introducing compile time breakages for clients.

- Modify all methods of `MetasysClient` and `IMetasysClient` that use `Guid` as an objectIdentifier to take an `ObjectId` instead. This is a non-breaking change due to the implicit conversion from `Guid` to `ObjectId` (unless clients are using Reflection to find methods).

- For `MetasysClient` and `IMetasysClient` methods that take an `IEnumerable<Guid>` we had to leave those methods. But we marked them obsolete, added new methods that take `IEnumerable<ObjectId>`. These new methods take their implementation from the old methods. The old methods delegate to the new methods so they are easy to delete in the future.


Future work: There are many other interfaces/methods that identify objects by `Guid`. This PR will be updated with those as well

- [x] Update README to remove use of Guid. 
- [x] Alarms
- [x] Audits
- [x] Trends
- [x] Spaces: Switch methods to use ObjectId instead of Guid
- [x] Equipment:  Switch methods to use ObjectId instead of Guid
- [x] Change MetasysObject.Id return type to ObjectId
- [x] Fix demo apps to use non-obsolete methods
- [x] Add tests that use new methods (not 100% needed as the old methods that
      are being called just delegate to the new methods.


> [!Note]
> Alarm, Audit and Activity guid identifiers will be left alone (for now). While those are also just documented as strings it just increases the scope of the change to be too large. So only Object identifiers are being targeted at this time. See #142 for the alarms and audits changes.