### PR TITLE
feat: use ActivityId for activity ids

### DIFF
--- a/MetasysServices.Tests/ActivityIdTests.cs
+++ b/MetasysServices.Tests/ActivityIdTests.cs
@@ -1,0 +1,58 @@
+using System;
+using NUnit.Framework;
+
+namespace JohnsonControls.Metasys.BasicServices;
+
+[TestFixture]
+public class ActivityIdTests
+{
+    // Mainly just making sure we never get a Null exception due to the default constructor
+    // This was really addressed by the fact that I switched ActivityId to be a record,
+    // changed the language in csproj to 12 and provided a default constructor that ensures
+    // we default to empty string
+    [Test]
+    public void DefaultInstanceNeverThrows()
+    {
+        // Arrange
+        var id = new ActivityId();
+
+        // Assertions
+        Assert.That(id.ToString(), Is.EqualTo(""));
+        Assert.That((string)id, Is.EqualTo(""));
+        Assert.That(id == "", Is.True);
+        Assert.That(id.GetHashCode(), Is.EqualTo(id.ToString().GetHashCode()));
+    }
+
+
+    // Basically make sure conversions to/from string are correct
+    [TestCase("")]
+    [TestCase("54efad4c-0fb7-59b4-9b6f-e385fd7e5b9e")]
+    [TestCase("Happy Data 😃")]
+    public void StringConversions(string inputString)
+    {
+        // Act
+        ActivityId activityId = inputString;
+
+        // Assert
+        Assert.That(activityId, Is.EqualTo(inputString));
+        Assert.That(activityId, Is.EqualTo(new ActivityId(inputString)));
+        Assert.That(inputString, Is.EqualTo(activityId));
+        Assert.That(inputString, Is.EqualTo(activityId.ToString()));
+        Assert.That(activityId == inputString, Is.True);
+        Assert.That(activityId != inputString, Is.False);
+        Assert.That(activityId != "78f5c3ca-46e1-5f93-b06e-5711677bf933", Is.True);
+    }
+
+    [TestCase("54efad4c-0fb7-59b4-9b6f-e385fd7e5b9e")]
+    public void GuidConversions(string inputString)
+    {
+        // Act
+        var guid = new Guid(inputString);
+        ActivityId activityId = guid;
+
+        // Assert
+        Assert.That(activityId, Is.EqualTo(guid));
+        Assert.That(activityId, Is.EqualTo(new ActivityId(inputString)));
+        Assert.That(guid, Is.EqualTo(activityId));
+    }
+}

--- a/MetasysServices/Activities/Activity.cs
+++ b/MetasysServices/Activities/Activity.cs
@@ -10,9 +10,9 @@ namespace JohnsonControls.Metasys.BasicServices
     /// <remarks> This is available since Metasys API v5. </remarks>
     public class Activity
     {
-        /// <summary> Activity Unique Identifier (GUID) </summary>
+        /// <summary> Activity Unique Identifier </summary>
         [JsonProperty(Required = Required.Always)]
-        public Guid Id { get; set; }
+        public ActivityId Id { get; set; }
 
         /// <summary> Item fully qualified reference </summary>
         [JsonProperty(Required = Required.Always)]
@@ -42,12 +42,12 @@ namespace JohnsonControls.Metasys.BasicServices
         public Guid ObjectId { get; set; }
 
         /// <summary>
-        /// Alarm object (in case the activityType = alarm) 
+        /// Alarm object (in case the activityType = alarm)
         /// </summary>
         public ActivityAlarm Alarm { get; set; }
 
         /// <summary>
-        /// Audit object (in case the activityType = audit) 
+        /// Audit object (in case the activityType = audit)
         /// </summary>
         public ActivityAudit Audit { get; set; }
 

--- a/MetasysServices/Alarms/Alarm.cs
+++ b/MetasysServices/Alarms/Alarm.cs
@@ -17,10 +17,10 @@ namespace JohnsonControls.Metasys.BasicServices
         public string Self { get; set; }
 
         /// <summary>
-        /// Alarm Unique Identifier (GUID)
+        /// Alarm Unique Identifier
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public Guid Id { get; set; }
+        public ActivityId Id { get; set; }
 
         /// <summary>
         /// Item fully qualified reference

--- a/MetasysServices/Alarms/AlarmServiceProvider.cs
+++ b/MetasysServices/Alarms/AlarmServiceProvider.cs
@@ -106,12 +106,12 @@ namespace JohnsonControls.Metasys.BasicServices
 
         //FindById ------------------------------------------------------------------------------------------------------------------
         /// <inheritdoc/>
-        public Alarm FindById(Guid alarmId)
+        public Alarm FindById(ActivityId alarmId)
         {
             return FindByIdAsync(alarmId).GetAwaiter().GetResult();
         }
         /// <inheritdoc/>
-        public async Task<Alarm> FindByIdAsync(Guid alarmId)
+        public async Task<Alarm> FindByIdAsync(ActivityId alarmId)
         {
             CheckVersion(Version);
 
@@ -188,13 +188,13 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        private void Edit(Guid alarmId, ActivityManagementStatusEnum action, string annotationText = null)
+        private void Edit(ActivityId alarmId, ActivityManagementStatusEnum action, string annotationText = null)
         {
             EditAsync(alarmId, action, annotationText).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        private async Task EditAsync(Guid alarmId, ActivityManagementStatusEnum action, string annotationText = null)
+        private async Task EditAsync(ActivityId alarmId, ActivityManagementStatusEnum action, string annotationText = null)
         {
             CheckVersion(Version);
 
@@ -219,13 +219,13 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public void Discard(Guid alarmId, string annotationText = null)
+        public void Discard(ActivityId alarmId, string annotationText = null)
         {
             DiscardAsync(alarmId, annotationText).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public async Task DiscardAsync(Guid alarmId, string annotationText = null)
+        public async Task DiscardAsync(ActivityId alarmId, string annotationText = null)
         {
             CheckVersion(Version);
 
@@ -250,13 +250,13 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public void Acknowledge(Guid alarmId, string annotationText = null)
+        public void Acknowledge(ActivityId alarmId, string annotationText = null)
         {
             AcknowledgeAsync(alarmId, annotationText).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public async Task AcknowledgeAsync(Guid alarmId, string annotationText = null)
+        public async Task AcknowledgeAsync(ActivityId alarmId, string annotationText = null)
         {
             CheckVersion(Version);
 
@@ -281,13 +281,13 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public IEnumerable<AlarmAnnotation> GetAnnotations(Guid alarmId)
+        public IEnumerable<AlarmAnnotation> GetAnnotations(ActivityId alarmId)
         {
             return GetAnnotationsAsync(alarmId).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<AlarmAnnotation>> GetAnnotationsAsync(Guid alarmId)
+        public async Task<IEnumerable<AlarmAnnotation>> GetAnnotationsAsync(ActivityId alarmId)
         {
             CheckVersion(Version);
 

--- a/MetasysServices/Alarms/IAlarmService.cs
+++ b/MetasysServices/Alarms/IAlarmService.cs
@@ -17,27 +17,27 @@ namespace JohnsonControls.Metasys.BasicServices
         ///// <param name="alarmId">The identifier of the alarm.</param>
         ///// <param name="action">Action: Acknowledged or Discarded.</param>
         ///// <param name="annotationText">Annotation Text (optional).</param>
-        //void Edit(Guid alarmId, ActivityManagementStatusEnum action, string annotationText = null);
-        ///// <inheritdoc cref="IAlarmsService.Edit(Guid, ActivityManagementStatusEnum, String)"/>
-        //Task EditAsync(Guid alarmId, ActivityManagementStatusEnum action, string annotationText = null);
+        //void Edit(ActivityId alarmId, ActivityManagementStatusEnum action, string annotationText = null);
+        ///// <inheritdoc cref="IAlarmsService.Edit(ActivityId, ActivityManagementStatusEnum, String)"/>
+        //Task EditAsync(ActivityId alarmId, ActivityManagementStatusEnum action, string annotationText = null);
 
         /// <summary>
         /// Set an Alarm as 'acknowledged'
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <param name="annotationText">Annotation Text (optional).</param>
-        void Acknowledge(Guid alarmId, string annotationText = null);
-        /// <inheritdoc cref="IAlarmsService.Acknowledge(Guid, String)"/>
-        Task AcknowledgeAsync(Guid alarmId, string annotationText = null);
+        void Acknowledge(ActivityId alarmId, string annotationText = null);
+        /// <inheritdoc cref="IAlarmsService.Acknowledge(ActivityId, String)"/>
+        Task AcknowledgeAsync(ActivityId alarmId, string annotationText = null);
 
         /// <summary>
         /// Set an Alarm as 'discarded'
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <param name="annotationText">Annotation Text (optional).</param>
-        void Discard(Guid alarmId, string annotationText = null);
-        /// <inheritdoc cref="IAlarmsService.Discard(Guid, String)"/>
-        Task DiscardAsync(Guid alarmId, string annotationText = null);
+        void Discard(ActivityId alarmId, string annotationText = null);
+        /// <inheritdoc cref="IAlarmsService.Discard(ActivityId, String)"/>
+        Task DiscardAsync(ActivityId alarmId, string annotationText = null);
 
         // --------------------------------------------------------------------------------------------------
         /// <summary>
@@ -45,10 +45,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="alarmId">The identifier of the alarm.</param>
         /// <returns>The specified alarm details.</returns>
-        Alarm FindById(Guid alarmId);
+        Alarm FindById(ActivityId alarmId);
 
-        /// <inheritdoc cref="IAlarmsService.FindById(Guid)"/>
-        Task<Alarm> FindByIdAsync(Guid alarmId);
+        /// <inheritdoc cref="IAlarmsService.FindById(ActivityId)"/>
+        Task<Alarm> FindByIdAsync(ActivityId alarmId);
 
         // --------------------------------------------------------------------------------------------------
         /// <summary>
@@ -77,10 +77,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="alarmId"></param>
         /// <returns></returns>
-        IEnumerable<AlarmAnnotation> GetAnnotations(Guid alarmId);
+        IEnumerable<AlarmAnnotation> GetAnnotations(ActivityId alarmId);
 
-        /// <inheritdoc cref="IAlarmsService.GetAnnotations(Guid)"/>
-        Task<IEnumerable<AlarmAnnotation>> GetAnnotationsAsync(Guid alarmId);
+        /// <inheritdoc cref="IAlarmsService.GetAnnotations(ActivityId)"/>
+        Task<IEnumerable<AlarmAnnotation>> GetAnnotationsAsync(ActivityId alarmId);
 
         // --------------------------------------------------------------------------------------------------
         /// <summary>

--- a/MetasysServices/Audits/Audit.cs
+++ b/MetasysServices/Audits/Audit.cs
@@ -12,10 +12,10 @@ namespace JohnsonControls.Metasys.BasicServices
     public class Audit
     {
         /// <summary>
-        /// The identifier of the audit(GUID).
+        /// The identifier of the audit.
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public Guid Id { get; set; }
+        public ActivityId Id { get; set; }
 
         /// <summary>
         /// The dateTime representing the creation time when this audit message was created.

--- a/MetasysServices/Audits/AuditServiceProvider.cs
+++ b/MetasysServices/Audits/AuditServiceProvider.cs
@@ -34,7 +34,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public async Task<Audit> FindByIdAsync(Guid auditId)
+        public async Task<Audit> FindByIdAsync(ActivityId auditId)
         {
             CheckVersion(Version);
 
@@ -108,7 +108,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<AuditAnnotation>> GetAnnotationsAsync(Guid auditId)
+        public async Task<IEnumerable<AuditAnnotation>> GetAnnotationsAsync(ActivityId auditId)
         {
             CheckVersion(Version);
 
@@ -138,7 +138,7 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public Audit FindById(Guid auditId)
+        public Audit FindById(ActivityId auditId)
         {
             return FindByIdAsync(auditId).GetAwaiter().GetResult();
         }
@@ -156,19 +156,19 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public IEnumerable<AuditAnnotation> GetAnnotations(Guid auditId)
+        public IEnumerable<AuditAnnotation> GetAnnotations(ActivityId auditId)
         {
             return GetAnnotationsAsync(auditId).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public void Discard(Guid id, string annotationText)
+        public void Discard(ActivityId id, string annotationText)
         {
             DiscardAsync(id, annotationText).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public async Task DiscardAsync(Guid id, string annotationText)
+        public async Task DiscardAsync(ActivityId id, string annotationText)
         {
             try
             {
@@ -202,13 +202,13 @@ namespace JohnsonControls.Metasys.BasicServices
         }
 
         /// <inheritdoc/>
-        public void AddAnnotation(Guid id, string text)
+        public void AddAnnotation(ActivityId id, string text)
         {
             AddAnnotationAsync(id, text).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc/>
-        public async Task AddAnnotationAsync(Guid id, string text)
+        public async Task AddAnnotationAsync(ActivityId id, string text)
         {
             try
             {
@@ -407,7 +407,7 @@ namespace JohnsonControls.Metasys.BasicServices
                 var respIds = r["id"].Value<string>().Split('_');
 
                 Result resultItem = new Result();
-                resultItem.Id = new Guid(respIds[0]); ;
+                resultItem.Id = new ActivityId(respIds[0]); ;
                 resultItem.Status = r["status"].Value<int>();
                 resultItem.Annotation = respIds[1];
                 results.Add(resultItem);
@@ -522,7 +522,7 @@ namespace JohnsonControls.Metasys.BasicServices
     public class Result
     {
         /// <summary>The id of the Audit affected by the call.</summary>
-        public Guid Id { set; get; }
+        public ActivityId Id { set; get; }
 
         /// <summary>The Status of the call.</summary>
         public int Status { set; get; }

--- a/MetasysServices/Audits/IAuditService.cs
+++ b/MetasysServices/Audits/IAuditService.cs
@@ -16,10 +16,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="auditId">The identifier of the audit.</param>
         /// <returns>The specified audit details.</returns>
-        Audit FindById(Guid auditId);
+        Audit FindById(ActivityId auditId);
 
-        /// <inheritdoc cref="IAuditService.FindById(Guid)"/>
-        Task<Audit> FindByIdAsync(Guid auditId);
+        /// <inheritdoc cref="IAuditService.FindById(ActivityId)"/>
+        Task<Audit> FindByIdAsync(ActivityId auditId);
 
         /// <summary>
         /// Retrieves a collection of audits.
@@ -36,10 +36,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// </summary>
         /// <param name="auditId"></param>
         /// <returns></returns>
-        IEnumerable<AuditAnnotation> GetAnnotations(Guid auditId);
+        IEnumerable<AuditAnnotation> GetAnnotations(ActivityId auditId);
 
-        /// <inheritdoc cref="IAuditService.GetAnnotations(Guid)"/>
-        Task<IEnumerable<AuditAnnotation>> GetAnnotationsAsync(Guid auditId);
+        /// <inheritdoc cref="IAuditService.GetAnnotations(ActivityId)"/>
+        Task<IEnumerable<AuditAnnotation>> GetAnnotationsAsync(ActivityId auditId);
 
         /// <summary>
         /// Retrieves a collection of audits for the specified object.
@@ -58,10 +58,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id">The identifier of the Audit.</param>
         /// <param name="annotationText">Text of the annotation to report the reason of the discard.</param>
         /// <exception cref="MetasysUnsupportedApiVersion"></exception>
-        void Discard(Guid id, string annotationText);
+        void Discard(ActivityId id, string annotationText);
 
-        /// <inheritdoc cref="IAuditService.Discard(Guid , string)"/>
-        Task DiscardAsync(Guid id, string annotationText);
+        /// <inheritdoc cref="IAuditService.Discard(ActivityId , string)"/>
+        Task DiscardAsync(ActivityId id, string annotationText);
 
         /// <summary>
         /// Add an Annotation to the specified Audit.
@@ -69,10 +69,10 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <param name="id">The identifier of the Audit.</param>
         /// <param name="text">The text of the Annotation.</param>
         /// <exception cref="MetasysUnsupportedApiVersion"></exception>
-        void AddAnnotation(Guid id, string text);
+        void AddAnnotation(ActivityId id, string text);
 
-        /// <inheritdoc cref="IAuditService.AddAnnotation(Guid, string)"/>
-        Task AddAnnotationAsync(Guid id, string text);
+        /// <inheritdoc cref="IAuditService.AddAnnotation(ActivityId, string)"/>
+        Task AddAnnotationAsync(ActivityId id, string text);
 
         /// <summary>
         /// Add many Annotations given a list of requests containing the Id of the Audits and the text of the Annotations.

--- a/MetasysServices/Models/ActivityId.cs
+++ b/MetasysServices/Models/ActivityId.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Security.Policy;
+
+namespace JohnsonControls.Metasys.BasicServices
+{
+    /// <summary>
+    /// A Metasys Activity Identifier
+    /// </summary>
+    /// <remarks>
+    /// An ActivityId uniquely identifies one audit or one alarm in the system
+    ///
+    /// Wherever an ActivityId is required you can pass a string instead.
+    ///
+    /// This is because this is just a token type to signify that an activity identifier is required.
+    /// As such it has implicit conversions to/from string.
+    /// </remarks>
+    public record struct ActivityId(string Value) : IEquatable<ActivityId>, IEquatable<string>, IEquatable<Guid>
+    {
+
+        public ActivityId() : this("")
+        {
+
+        }
+
+        /// <summary>
+        /// Implicitly convert an <see cref="ActivityId"/> to <see cref="string"/>
+        /// </summary>
+        /// <param name="activityId"></param>
+        public static implicit operator string(ActivityId activityId)
+        {
+            return activityId.Value;
+        }
+
+        /// <summary>
+        /// Implicitly convert a <see cref="string"/> to <see cref="ActivityId"/>
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ActivityId(string value)
+        {
+            return new ActivityId(value);
+        }
+
+        /// <summary>
+        /// Implicitly convert a <see cref="Guid"/> to <see cref="ActivityId"/>
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ActivityId(Guid value)
+        {
+            return new ActivityId(value.ToString());
+        }
+
+        /// <summary>
+        /// <s>Implicitly convert a <see cref="ActivityId"/> to <see cref="Guid"/></s>
+        /// </summary>
+        /// <remarks>
+        /// <b>This method is deprecated.</b> This method is not guaranteed to always succeed
+        /// in the future. While Metasys activity identifiers have always safely converted to Guids
+        /// they make no guarantee that they will always. Nor does the REST API spec document
+        /// them as Guids.
+        /// <para>
+        /// To avoid issues, use methods from this library that take an <see cref="ActivityId"/> for
+        /// alarm or audit identifiers. You can even pass strings to those methods as strings will implicitly
+        /// convert to ActivityId.
+        /// </para>
+        /// </remarks>
+        /// <param name="activityId"></param>
+        // As of writing this should never throw as Metasys currently uses
+        // guids for identifiers. But it doesn't advertise this and doesn't
+        // guarantee it. Which is why the Guid operators have been deprecated
+        // and why this class was created.
+        // This operator is as safe as using Guids in all of the demo apps
+        // today. Any one of them could throw if an activity id was goofed up.
+        [Obsolete("This is not guaranteed to always succeed. Please use methods that use strings or ActivityIds for activity identifiers instead.")]
+        public static implicit operator Guid(ActivityId activityId)
+        {
+            if (Guid.TryParse(activityId, out Guid value))
+            {
+                return value;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(activityId), "Value must contain a valid guid.");
+        }
+
+        /// <inheritdoc cref="object.GetHashCode"/>
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /// <inheritdoc cref="object.ToString"/>
+        public override string ToString()
+        {
+            return Value;
+        }
+
+        /// <inheritdoc cref="IEquatable{T}"/>
+        public bool Equals(ActivityId other)
+        {
+            return Value == other.Value;
+        }
+
+        /// <inheritdoc cref="IEquatable{T}"/>
+        public bool Equals(string other)
+        {
+            return Value == other;
+        }
+
+        /// <inheritdoc cref="object.Equals(object)"/>
+        public bool Equals(Guid other)
+        {
+            return other.ToString() == Value;
+        }
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Metasys Basic Services <!-- omit in toc --> <a href="https://www.nuget.org/packages/JohnsonControls.Metasys.BasicServices/" rel="Johnson Controls Metasys BasicServices">![Nuget](https://img.shields.io/nuget/v/JohnsonControls.Metasys.BasicServices)</a>
+<!-- omit in toc --> 
+# Metasys Basic Services <a href="https://www.nuget.org/packages/JohnsonControls.Metasys.BasicServices/" rel="Johnson Controls Metasys BasicServices">![Nuget](https://img.shields.io/nuget/v/JohnsonControls.Metasys.BasicServices)</a>
 
 This project provides a library for accessing the most common services of the Metasys Server API.
 The intent is to provide an API that is very similar to the original MSSDA
@@ -18,7 +19,7 @@ For versioning information see the [changelog](CHANGELOG.md).
   - [Login and Access Tokens](#login-and-access-tokens)
   - [Localization of Metasys Enumerations](#localization-of-metasys-enumerations)
   - [Metasys Objects](#metasys-objects)
-    - [Get Object Id](#Get-object-Id)
+    - [Get Object Id](#get-object-id)
     - [Get a Property](#get-a-property)
     - [Write a Property](#write-a-property)
     - [Get and Send Commands](#get-and-send-commands)
@@ -53,7 +54,7 @@ For versioning information see the [changelog](CHANGELOG.md).
     - [Get Alarms for an Object](#get-alarms-for-an-object)
     - [Get Alarms for a Network Device](#get-alarms-for-a-network-device)
     - [Get Alarm Annotations](#get-alarm-annotations)
-    - [Acknowlege an Alarm](#acknowledge-an-alarm)
+    - [Acknowledge an Alarm](#acknowledge-an-alarm)
     - [Discard an Alarm](#discard-an-alarm)
   - [Audits](#audits)
     - [Get Audits](#get-audits)
@@ -76,20 +77,20 @@ For versioning information see the [changelog](CHANGELOG.md).
     - [Edit a Custom Enumeration](#edit-a-custom-enumeration)
     - [Replace a Custom Enumeration](#replace-a-custom-enumeration)
     - [Delete a Custom Enumeration](#delete-a-custom-enumeration)
-  - [Streams](#Streams)
+  - [Streams](#streams)
     - [Reading Object PresentValue COV](#reading-object-presentvalue-cov)
     - [Collecting Alarm Events](#collecting-alarm-events)
     - [Collecting Audit Events](#collecting-audit-events)
     - [Keep the Stream Alive](#keep-the-stream-alive)
   - ['Ad-Hoc' call](#ad-hoc-call)
     - [SendAsync](#sendasync)
-  - [Activities](#Activities)
-    - [Get Activities](#get-activities)
+  - [Activities](#activities-1)
+    - [Get Activities](#get-activities-1)
     - [Multiple Actions](#multiple-actions)
 - [Usage (COM)](#usage-com)
   - [Creating a Client](#creating-a-client-1)
   - [Login and Access Tokens](#login-and-access-tokens-1)
-  - [Metasys Objects](#metasys-objects)
+  - [Metasys Objects](#metasys-objects-1)
     - [Get Object Id](#get-object-id-1)
     - [Get a Property](#get-a-property-1)
     - [Write a Property](#write-a-property-1)
@@ -123,7 +124,7 @@ For versioning information see the [changelog](CHANGELOG.md).
     - [Get Alarms for an Object](#get-alarms-for-an-object-1)
     - [Get Alarms for a Network Device](#get-alarms-for-a-network-device-1)
     - [Get Alarm Annotations](#get-alarm-annotations-1)
-    - [Acknowlege an Alarm](#acknowledge-an-alarm-1)
+    - [Acknowledge an Alarm](#acknowledge-an-alarm-1)
     - [Discard an Alarm](#discard-an-alarm-1)
   - [Audits](#audits-1)
     - [Get Audits](#get-audits-1)
@@ -146,7 +147,7 @@ For versioning information see the [changelog](CHANGELOG.md).
     - [Edit a Custom Enumeration](#edit-a-custom-enumeration-1)
     - [Replace a Custom Enumeration](#replace-a-custom-enumeration-1)
     - [Delete a Custom Enumeration](#delete-a-custom-enumeration-1)
-  - [Streams](#Streams-1)
+  - [Streams](#streams-1)
     - [Reading Object PresentValue COV](#reading-object-presentvalue-cov-1)
     - [Collecting Alarm Events](#collecting-alarm-events-1)
     - [Collecting Audit Events](#collecting-audit-events-1)
@@ -1275,7 +1276,7 @@ Console.WriteLine(audit);
 <br/>
 
 #### Get Single Audit
-To get a single audit you can use the method **`Audits.FindById`** which returns an Audit object with all the details given the Guid.
+To get a single audit you can use the method **`Audits.FindById`** which returns an Audit object with all the details given the Id.
 <br/>
 
 #### Get Audits for an Object
@@ -1290,7 +1291,7 @@ var objectAudits = client.Audits.GetForObject(objectId, auditFilter);
 
 #### Get Audit Annotations
 To get the annotations of an audit you can use the method **`Audits.GetAnnotations`**.   
-It required the Guid of the audit and returns a collection of 'AuditAnnotation' objects.
+It requires the Id of the audit and returns a collection of 'AuditAnnotation' objects.
 ```csharp
 IEnumerable<AuditAnnotation> annotations = client.Audits.GetAnnotations(audit.Id);
 AuditAnnotation firstAnnotation = annotations.FirstOrDefault();
@@ -1314,7 +1315,7 @@ Console.WriteLine(firstAnnotation);
 To allow for discarding an audit you can use the method **`Audits.Discard`**.  
 This method expects an audit Id and optionally you can also add an annotation.
 ```csharp
-Guid auditId = new Guid("9cf1c11d-a8cc-48e6-9e4c-f02af26e8fdf");
+var auditId = "9cf1c11d-a8cc-48e6-9e4c-f02af26e8fdf";
 string annotationText = "Reason why the audit has been discarded";
 client.Audits.Discard(auditId, annotationText);
 ``` 
@@ -1324,7 +1325,7 @@ client.Audits.Discard(auditId, annotationText);
 > Available since API v3
 > 
 To discard multiple Audits you can use the method **`Audits.DiscardMultiple`**.  
-It takes a list of 'BatchRequestParam' objects (specifing the list of Audit Guids and annotations) and it returns a list of 'Result' objects.
+It takes a list of 'BatchRequestParam' objects (specifying the list of Audit Ids and annotations) and it returns a list of 'Result' objects.
 ```csharp
 var requests = new List<BatchRequestParam>();
 BatchRequestParam request1 = new BatchRequestParam { ObjectId = "e0fb025a-d8a2-4258-91ea-c4026c1620d1", Resource = "THIS IS THE FIRST DISCARD ANNOTATION" };
@@ -1349,9 +1350,9 @@ Console.WriteLine(resultItem);
 > Available since API v3
 > 
 To add an Annotation to an Audit you can use the method **`Audits.AddAnnotation`**.   
-It takes the Guid of the Audit and the text of the annotation you want to add. It doesn't return a value.
+It takes the Id of the Audit and the text of the annotation you want to add. It doesn't return a value.
 ```csharp
-Guid auditId = new Guid("9cf1c11d-a8cc-48e6-9e4c-f02af26e8fdf");
+var auditId = "9cf1c11d-a8cc-48e6-9e4c-f02af26e8fdf";
 string annotationText = "This is the text of the annotation";
 client.Audits.AddAnnotation(auditId, annotationText);
 ``` 
@@ -1361,8 +1362,8 @@ client.Audits.AddAnnotation(auditId, annotationText);
 > Available since API v3
 > 
 To add multiple Annotations to an Audit you can use the method **`Audits.AddAnnotationMultiple`**.  
-It takes a list of 'BatchRequestParam' objects (specifing the list of Audit Guids and annotations) and it returns a list of 'Result' objects.
-```sharp
+It takes a list of 'BatchRequestParam' objects (specifying the list of Audit Ids and annotations) and it returns a list of 'Result' objects.
+```csharp
 var requests = new List<BatchRequestParam>();
 BatchRequestParam request1 = new BatchRequestParam { ObjectId = "e0fb025a-d8a2-4258-91ea-c4026c1620d1", Resource = "THIS IS THE FIRST AUDIT ANNOTATION" };
 requests.Add(request1);
@@ -2011,7 +2012,7 @@ pages=auditsPager.PageCount
 <br/>
 
 #### Get Single Audit
-To get a single audit you can use the method **`GetSingleAudit`** which returns an 'ComAudit' object with all the details given the Guid.
+To get a single audit you can use the method **`GetSingleAudit`** which returns an 'ComAudit' object with all the details given the Id.
 <br/>
 
 #### Get Audits for an Object
@@ -2027,7 +2028,7 @@ objectAudits = objectAuditsPager.Items
 
 #### Get Audit Annotations
 To get the annotations of an audit you can use the method **`GetAuditAnnotations`**.   
-It required the Guid of the audit and returns a collection of 'AuditAnnotation' objects.
+It requires the Id of the audit and returns a collection of 'AuditAnnotation' objects.
 ```vb
 Dim auditId As String
 auditId = "6c999f43-6007-5137-b6d3-c30b93fb70ec"
@@ -2074,7 +2075,7 @@ result = client.DiscardAuditMultiple(auditId)
 > Available since API v3
 > 
 To add an Annotation to an Audit you can use the method **`AddAuditAnnotation`**.   
-It takes the Guid of the Audit and the text of the annotation you want to add. It doesn't return a value.
+It takes the Id of the Audit and the text of the annotation you want to add. It doesn't return a value.
 <br/>
 
 #### Add Multiple Audit Annotations
@@ -2300,5 +2301,3 @@ See [CONTRIBUTING](CONTRIBUTING).
 - zh-TW
 ### Customizing Windows IIS for Metasys API
 To get further information about customizing Windows IIS for Metasys API click [here](https://docs.johnsoncontrols.com/bas/r/Metasys-Server/11.0/Metasys-Server-Installation-and-Upgrade-Instructions/Customizing-Windows-IIS-for-Metasys-API)
-
-


### PR DESCRIPTION
Rather than tie ourselves to GUIDs which the Metasys REST API does not guarantee, switch to using AcivityId for activities, audits, and alarms. This is a token type that easily converts to/from string and to/from Guid.