### PR TITLE
fix #145 by handling trees from server

### DIFF
--- a/MetasysServices.Tests/MetasysObjectTests.cs
+++ b/MetasysServices.Tests/MetasysObjectTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace JohnsonControls.Metasys.BasicServices;
+
+public class MetasysObjectTests
+{
+
+
+    [Test]
+    public void Test()
+    {
+        // Arrange
+        var objectTree = JsonConvert.DeserializeObject<JToken>(ObjectTreeThreeLevels);
+
+        // Act
+        var metasysObject = new MetasysObject(objectTree, ApiVersion.v4);
+
+        // Assertions
+        Assert.That(metasysObject.ChildrenCount == 2);
+        Assert.That(metasysObject.Children.First().ChildrenCount == 3);
+    }
+
+
+
+    private const string ObjectTreeThreeLevels = @"
+        {
+            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics"",
+            ""name"": ""Graphics"",
+            ""id"": ""76609398-fa4b-51e0-bfa3-eab94d289241"",
+            ""objectType"": ""objectTypeEnumSet.containerClass"",
+            ""classification"": ""folder"",
+            ""items"": [
+                {
+                    ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Common"",
+                    ""name"": ""Common"",
+                    ""id"": ""55bd3987-6e6a-567d-8894-59684d2358d9"",
+                    ""objectType"": ""objectTypeEnumSet.containerClass"",
+                    ""classification"": ""folder"",
+                    ""items"": [
+                        {
+                            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Common.Lighting"",
+                            ""name"": ""Lighting"",
+                            ""id"": ""ccaf1ca6-4ad5-5d07-a177-c38f68ae8235"",
+                            ""objectType"": ""objectTypeEnumSet.xamlGraphicClass"",
+                            ""classification"": """",
+                            ""items"": []
+                        },
+                        {
+                            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Common.Lighting_Alt"",
+                            ""name"": ""Lighting_Alt"",
+                            ""id"": ""f80ba7bb-6f9e-571f-a8c1-e1162ff20870"",
+                            ""objectType"": ""objectTypeEnumSet.xamlGraphicClass"",
+                            ""classification"": """",
+                            ""items"": []
+                        },
+                        {
+                            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Common.Weather Data"",
+                            ""name"": ""Weather Data"",
+                            ""id"": ""a7a4bd74-a4c4-53cb-b316-2c14f627e8bc"",
+                            ""objectType"": ""objectTypeEnumSet.xamlGraphicClass"",
+                            ""classification"": """",
+                            ""items"": []
+                        }
+                    ]
+                },
+                {
+                    ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Hospital"",
+                    ""name"": ""Hospital"",
+                    ""id"": ""dca754ae-811e-5e7a-896c-f9fee7446b82"",
+                    ""objectType"": ""objectTypeEnumSet.containerClass"",
+                    ""classification"": ""folder"",
+                    ""items"": [
+                        {
+                            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Hospital.AHU-2"",
+                            ""name"": ""AHU-2"",
+                            ""id"": ""22a56b58-f5b6-55fb-9828-c7f0ce96ae2e"",
+                            ""objectType"": ""objectTypeEnumSet.xamlGraphicClass"",
+                            ""classification"": """",
+                            ""items"": []
+                        },
+                        {
+                            ""itemReference"": ""R12AdsDaily:R12AdsDaily/Graphics.Hospital.2ND_FLR"",
+                            ""name"": ""2ND_FLR"",
+                            ""id"": ""61839195-b443-56d4-a768-5bc7c0e61416"",
+                            ""objectType"": ""objectTypeEnumSet.xamlGraphicClass"",
+                            ""classification"": """",
+                            ""items"": []
+                        }
+                    ]
+                }
+            ]
+        }";
+
+}

--- a/MetasysServices/MetasysClient.cs
+++ b/MetasysServices/MetasysClient.cs
@@ -124,6 +124,7 @@ namespace JohnsonControls.Metasys.BasicServices
                 if (Spaces != null) { Spaces.Version = version.Value; }
                 if (Streams != null) { Streams.Version = version.Value; }
                 if (Trends != null) { Trends.Version = version.Value; }
+                base.Version = value;
             }
         }
 
@@ -513,10 +514,12 @@ namespace JohnsonControls.Metasys.BasicServices
                 parameters = new Dictionary<string, string>
                 {
                     { "depth", levels.ToString() },
-                    { "flatten", "true".ToString() }, //This parameter is needed to get the data in a 'flat' way and keep consistency in the logic to retrieve the objects
-                    { "includeExtensions", includeExtensions.ToString() },
-                    { "includeInternal", includeInternalObjects.ToString() } //This param has different name when version > v3
+                    { "flatten", "false" },
+                    { "includeExtensions", includeExtensions.ToString().ToLower() },
+                    { "includeInternal", includeInternalObjects.ToString().ToLower() } //This param has different name when version > v3
                 };
+
+                return await GetObjectsAsync(id, parameters);
             }
 
             var objects = await GetObjectChildrenAsync(id, parameters, levels).ConfigureAwait(false);

--- a/MetasysServices/Models/MetasysObject.cs
+++ b/MetasysServices/Models/MetasysObject.cs
@@ -65,8 +65,8 @@ namespace JohnsonControls.Metasys.BasicServices
         /// <summary>
         /// The number of direct children objects.
         /// </summary>
-        /// <value>The number of children or -1 if there is no children data.</value>
-        public int ChildrenCount { set; get; }
+        /// <value>The number of children.</value>
+        public int ChildrenCount => Children.Count();
 
         /// <summary>
         /// Name of the Equipment Definition mapped with the Equipment Instance
@@ -84,12 +84,29 @@ namespace JohnsonControls.Metasys.BasicServices
         public string Classification { get; set; }
         private const string DefaultClassification = "object";
 
+        /// <summary>
+        /// Create a tree of objects out of a root node
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="version"></param>
+        internal MetasysObject(JToken token, ApiVersion version)
+        {
+            var root = token;
+            var children = root["items"] as JArray;
+            Initialize(root, version);
+
+            Children = children?.Select(child => new MetasysObject(child, version)).ToList() ?? [];
+        }
+
         internal MetasysObject(JToken token, ApiVersion version, IEnumerable<MetasysObject> children = null, MetasysObjectTypeEnum? type = null)
         {
             Children = children ?? new List<MetasysObject>(); // Return empty list by convention for null
-            ChildrenCount = Children?.Count() ?? 0; // Children count is 0 when children is null
             Type = type;
+            Initialize(token, version);
+        }
 
+        private void Initialize(JToken token, ApiVersion version)
+        {
             JObject jobj = token.ToObject<JObject>();
             try
             {


### PR DESCRIPTION
Prior to version 4 of the API we had to recursively fetch objects to simulate a depth parameter. But the library wasn't handling trees correctly when it used depths > 1. This resolves the issue by writing a new method that handles GetObjects when version > 3.

Fixes #145 